### PR TITLE
Header WebReview Enhancements

### DIFF
--- a/src/components/DocsButton.tsx
+++ b/src/components/DocsButton.tsx
@@ -6,7 +6,7 @@ export default function DocsButton() {
   const intl = useIntl()
   return (
     <LocalizedLink to="/v3/docs/getting-started/overview">
-      <button className="flex items-center justify-center bg-substrateDark dark:bg-white text-white dark:text-black text-sm py-2 w-20 rounded opacity-100 hover:opacity-80 focus:outline-none">
+      <button className="flex items-center justify-center bg-substrateDark dark:bg-white text-white dark:text-black text-sm py-2 w-20 rounded opacity-100 transform transition duration-300 ease-in-out hover:opacity-80 focus:outline-none">
         {/* <img src={docsIcon} alt="Substrate Docs Icon" /> */}
         <svg
           className="fill-current text-white dark:text-black"

--- a/src/components/Header/DropDownMenu.tsx
+++ b/src/components/Header/DropDownMenu.tsx
@@ -58,7 +58,7 @@ export default function DropDown({ menuData, index }: DropDownMenuProps) {
         }`}
       >
         <ul
-          className={`list-none relative bg-white dark:bg-black shadow-lg ring-1 ring-substrateDark dark:ring-white rounded-md ${
+          className={`list-none relative py-2 bg-white dark:bg-black shadow-lg ring-1 ring-substrateDark dark:ring-white rounded-md ${
             itemNavOpen ? `rounded-tr-none rounded-br-none` : null
           }`}
         >

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -82,7 +82,10 @@ export default function Header() {
           {/* ------------------ */}
           {/* Mobile Navigation */}
           {/* ------------------ */}
-          <div className="lg:hidden" onClick={() => toggleMenu()}>
+          <div
+            className="lg:hidden cursor-pointer"
+            onClick={() => toggleMenu()}
+          >
             <svg
               className="fill-current text-black dark:text-white"
               xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Header/NavListItem.tsx
+++ b/src/components/Header/NavListItem.tsx
@@ -14,7 +14,7 @@ export default function NavListItem({
 }: NavListItemProps) {
   const [isCurrent, setIsCurrent] = useState(false)
   const styles =
-    'px-6 py-4 -mb-1 focus:outline-none focus:bg-substrateBlueBg hover:text-substrateGreen hover:underline dark:text-white font-medium'
+    'px-6 py-2 -mb-1 focus:outline-none focus:bg-substrateBlueBg hover:text-substrateGreen hover:underline dark:text-white font-medium'
   useEffect(() => {
     if (link === location.pathname) {
       setIsCurrent(true)

--- a/src/components/Header/SubMenuItem.tsx
+++ b/src/components/Header/SubMenuItem.tsx
@@ -26,9 +26,9 @@ export default function SubMenuItem({
       <div
         ref={ref}
         onClick={() => setIsComponentVisible(!isComponentVisible)}
-        className={`px-6 py-4 -mb-1 text-black dark:text-white cursor-pointer rounded-md ${
+        className={`px-6 py-2 -mb-1 text-black dark:text-white cursor-pointer rounded-md ${
           isComponentVisible
-            ? 'bg-substrateGreen-light dark:bg-gray-900 hover:text-black'
+            ? 'bg-substrateGreen-light underline dark:bg-gray-900 hover:text-black'
             : 'hover:text-substrateGreen hover:underline'
         }`}
       >
@@ -54,7 +54,7 @@ export default function SubMenuItem({
       </div>
       {isComponentVisible ? (
         <>
-          <div className="list-none absolute top-0 -right-56 w-56 h-[336px] rounded-tr-md rounded-br-md shadow-lg ring-1 ring-black dark:ring-white bg-white dark:bg-black">
+          <div className="absolute top-0 -right-56 w-56 h-[256px] py-2 rounded-tr-md rounded-br-md shadow-lg ring-1 ring-black dark:ring-white bg-white dark:bg-black">
             {data.items.map((item, index) => {
               return (
                 <div key={index}>

--- a/src/components/MobileMenus/MobileDropDown.tsx
+++ b/src/components/MobileMenus/MobileDropDown.tsx
@@ -19,10 +19,12 @@ export default function MobileDropDown({
     <div>
       <div
         onClick={() => setIsComponentVisible(!isComponentVisible)}
-        className="px-6 py-3 hover:bg-substrateGreen-light text-black dark:text-white cursor-pointer"
+        className={`px-6 py-3 hover:font-bold text-black dark:text-white cursor-pointer ${
+          isComponentVisible ? 'font-bold' : 'font-medium'
+        }`}
       >
         <div className="flex justify-between items-center">
-          <span className="text-lg font-medium">{title}</span>
+          <span className="text-lg">{title}</span>
           <svg
             className={`transform ${
               isComponentVisible ? '-rotate-90' : 'rotate-90'
@@ -46,7 +48,8 @@ export default function MobileDropDown({
       {isComponentVisible ? (
         <>
           {items.map((each, index) => {
-            const itemStyles = 'block font-medium pl-12 mb-0 py-3'
+            const itemStyles =
+              'block font-medium hover:font-bold pl-12 mb-0 py-3'
             if (external) {
               return (
                 <a key={index} href={each.link}>

--- a/src/components/MobileMenus/MobileMenu.tsx
+++ b/src/components/MobileMenus/MobileMenu.tsx
@@ -35,7 +35,7 @@ const MobileMenu = ({ theme, toggleMenu, navItems }: MobileMenuProps) => {
 
   return (
     <nav className="lg:hidden absolute inset-0 bg-substrateGray-light dark:bg-black z-90 animate-fade-in-right">
-      <div className="h-16 px-4 flex items-center justify-between">
+      <div className="h-16 px-6 flex items-center justify-between">
         <div>
           <div className="w-32">
             <LocalizedLink to="/">
@@ -64,7 +64,7 @@ const MobileMenu = ({ theme, toggleMenu, navItems }: MobileMenuProps) => {
             </LocalizedLink>
           </div>
         </div>
-        <div onClick={() => toggleMenu()} className="h-auto">
+        <div onClick={() => toggleMenu()} className="h-auto cursor-pointer">
           <svg
             className="fill-current text-Black dark:text-white"
             width="20"
@@ -93,9 +93,9 @@ const MobileMenu = ({ theme, toggleMenu, navItems }: MobileMenuProps) => {
                     ? setIsEcoMenuOpen(!isEcoMenuOpen)
                     : null
                 }}
-                className="py-3 hover:bg-substrateGreen-light dark:hover:bg-gray-700"
+                className="py-3 hover:bg-substrateGreen-light dark:hover:bg-gray-700 font-medium transform transition-all duration-75 ease-in-out hover:font-bold"
               >
-                <div className="px-4 flex items-center justify-between focus:outline-none">
+                <div className="px-6 flex items-center justify-between focus:outline-none cursor-pointer">
                   <div className="text-2xl">{item.name}</div>
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/MobileMenus/MobileNavItem.tsx
+++ b/src/components/MobileMenus/MobileNavItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { LocalizedLink } from 'gatsby-theme-i18n'
 
 interface MobileNavItemProps {
@@ -12,12 +12,21 @@ export default function MobileNavItem({
   link,
   title,
 }: MobileNavItemProps) {
+  const [isActive, setIsActive] = useState(false)
+  useEffect(() => {
+    if (location.pathname === link) {
+      setIsActive(true)
+    } else {
+      setIsActive(false)
+    }
+  }, [])
   const styles =
-    'text-black dark:text-white hover:no-underline px-6 py-3 hover:bg-substrateGreen-light text-lg font-medium'
+    'text-black dark:text-white hover:no-underline px-6 py-3 text-lg hover:font-bold'
+  const activeStyles = () => (isActive ? `font-bold` : `font-medium`)
   if (external) {
     return (
       <a href={link}>
-        <div className={`${styles}`}>
+        <div className={`${styles} ${activeStyles()}`}>
           <span>{title}</span>
         </div>
       </a>
@@ -25,7 +34,7 @@ export default function MobileNavItem({
   } else {
     return (
       <LocalizedLink to={link}>
-        <div className={`${styles}`}>
+        <div className={`${styles} ${activeStyles()}`}>
           <span>{title}</span>
         </div>
       </LocalizedLink>

--- a/src/components/MobileMenus/MobileSubMenu.tsx
+++ b/src/components/MobileMenus/MobileSubMenu.tsx
@@ -24,7 +24,7 @@ export default function TechSubMenu({
     <div className="absolute inset-0 bg-substrateGray-light dark:bg-black h-screen animate-fade-in-right">
       <div className="bg-substrateGreen-light dark:bg-gray-900">
         <div className="px-6 h-16 flex items-center justify-between">
-          <div onClick={() => toggleSubMenu()}>
+          <div onClick={() => toggleSubMenu()} className="cursor-pointer">
             <svg
               className="fill-current text-black dark:text-white"
               width="20"
@@ -37,7 +37,7 @@ export default function TechSubMenu({
           </div>
 
           <span className="text-xl font-bold">{navItem.name}</span>
-          <div onClick={() => toggleMobileNav()}>
+          <div onClick={() => toggleMobileNav()} className="cursor-pointer">
             <svg
               className="fill-current text-black dark:text-white"
               width="20"


### PR DESCRIPTION
- [x] Reduce letter spacing between nav items to 1rem
- [x] Need more margin at top and bottom of menu pulldowns-- text is too tight against edges
- [x]  When user clicks on Opportunities and right side of menu pops out, the word 'Opportunities' should be underlined, per design (nice to have)
- [x] Mobile: increase font weight for Technology  Developers Vision. Ecosystem text (but leave text on next level the same)
- [x] Mobile: Left margin too tight (need 10-15px more whitespace between menu and edge of screen)
- [x]  Mobile/smaller screen: per design, text should get bold when hovered, selected ( nice to have)
- [x]  Mobile/smaller screen: hamburger menu > cursor should turn to hand on hover
- [x]  Hover state: add milsecond transition

