### PR TITLE
Update How-to Guide landing page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,6 +13,14 @@ const redirects = [
   { fromPath: '/v3/tools', toPath: '/v3/tools/subkey' },
   { fromPath: '/v3/advanced', toPath: '/v3/advanced/account-info' },
   { fromPath: '/tutorials/v3/kitties', toPath: `/tutorials/v3/kitties/pt1` },
+  { fromPath: '/how-to-guides/basics', toPath: `/how-to-guides/v3/basics/pallet-integration` },
+  { fromPath: '/how-to-guides/pallet-design', toPath: `/how-to-guides/v3/pallet-design/contracts-pallet` },
+  { fromPath: '/how-to-guides/weights', toPath: `/how-to-guides/v3/weights/calculate-fees` },
+  { fromPath: '/how-to-guides/testing', toPath: `/how-to-guides/v3/testing/basics` },
+  { fromPath: '/how-to-guides/storage-migrations', toPath: `/how-to-guides/v3/storage-migrations/basics` },
+  { fromPath: '/how-to-guides/consensus', toPath: `/how-to-guides/v3/consensus/pow` },
+  { fromPath: '/how-to-guides/parachains', toPath: `/how-to-guides/v3/parachains/preparing-an-upgrade` },
+  { fromPath: '/how-to-guides/tools', toPath: `/how-to-guides/v3/tools/try-runtime` },
 ]
 
 const tutsInfo = [

--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -122,6 +122,8 @@
   "htg-pallet-design-randomness": "Implementing Randomness",
   "htg-pallet-design-crowdfund": "Simple Crowdfund",
   "htg-pallet-design-storage-value": "Storage Value Struct",
+  "htg-tightly-coupling-pallets": "Tightly Coupling a Pallet",
+  "htg-loosely-coupling-pallets": "Loosely Coupling a Pallet",
 
   "docs-nav-htg-weights": "Weights",
   "htg-weights-calculate-fees": "Calculating Fees",

--- a/i18n/react-intl/fr.json
+++ b/i18n/react-intl/fr.json
@@ -121,6 +121,8 @@
   "htg-pallet-design-randomness": "Implementing Randomness",
   "htg-pallet-design-crowdfund": "Simple Crowdfund",
   "htg-pallet-design-storage-value": "Storage Value Struct",
+  "htg-tightly-coupling-pallets": "Tightly Coupling a Pallet",
+  "htg-loosely-coupling-pallets": "Loosely Coupling a Pallet",
 
   "docs-nav-htg-weights": "Weights",
   "htg-weights-calculate-fees": "Calculating Fees",

--- a/i18n/react-intl/zh-CN.json
+++ b/i18n/react-intl/zh-CN.json
@@ -121,6 +121,8 @@
   "htg-pallet-design-randomness": "Implementing Randomness",
   "htg-pallet-design-crowdfund": "Simple Crowdfund",
   "htg-pallet-design-storage-value": "Storage Value Struct",
+  "htg-tightly-coupling-pallets": "Tightly Coupling a Pallet",
+  "htg-loosely-coupling-pallets": "Loosely Coupling a Pallet",
 
   "docs-nav-htg-weights": "Weights",
   "htg-weights-calculate-fees": "Calculating Fees",

--- a/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Loosely Coupling Your Pallet
+title: Loosely Coupling a Pallet
 slug: /how-to-guides/v3/pallet-design/loose-coupling
 version: 3.0
 section: how to guides

--- a/v3/how-to-guides/index.mdx
+++ b/v3/how-to-guides/index.mdx
@@ -19,8 +19,7 @@ specific goal they want to achieve. Learn more about contributing to these guide
   link={`/how-to-guides/basics`}
   />
 <RelatedMaterialBlock
-  text={`A collection of guides that cover common concepts for building pallets using FRAME, with specific use cases to 
-  give meaningful context to each guide.`}
+  text={`A collection of best practices on building pallets using FRAME.`}
   linkText={`Pallet Design`}
   link={`/how-to-guides/pallet-design`}
   

--- a/v3/how-to-guides/index.mdx
+++ b/v3/how-to-guides/index.mdx
@@ -16,47 +16,47 @@ specific goal they want to achieve. Learn more about contributing to these guide
   text={`Learn the simple patterns that runtime engineers know inside out. These guides cover the basics 
   that will help you understand more complex topics.`}
   linkText={`Basics`}
-  link={`/how-to-guides/v3/basics`}
+  link={`/how-to-guides/basics`}
   />
 <RelatedMaterialBlock
   text={`A collection of guides that cover common concepts for building pallets using FRAME, with specific use cases to 
   give meaningful context to each guide.`}
   linkText={`Pallet Design`}
-  link={`/how-to-guides/v3/pallet-design`}
+  link={`/how-to-guides/pallet-design`}
   
 />
 <RelatedMaterialBlock
   text={`All guides about benchmarking and weight configurations for runtime engineers.`}
   linkText={`Weights`}
-  link={`/how-to-guides/v3/weights`}
+  link={`/how-to-guides/weights`}
   
 />
 <RelatedMaterialBlock
   text={`Guides to cover different use cases for testing pallets and other runtime logic.`}
   linkText={`Testing`}
-  link={`/how-to-guides/v3/testing`}
+  link={`/how-to-guides/testing`}
   
 />
 <RelatedMaterialBlock
   text={`A collection of guides to help runtime engineers with different types of storage migrations.`}
   linkText={`Storage Migrations`}
-  link={`/how-to-guides/v3/storage-migrations`}
+  link={`/how-to-guides/storage-migrations`}
   
 />
 <RelatedMaterialBlock
   text={`Discover different ways to implement consensus mechanisms in your runtimes.`}
   linkText={`Consensus`}
-  link={`/how-to-guides/v3/consensus`}
+  link={`/how-to-guides/consensus`}
 />
 <RelatedMaterialBlock
   text={`All things releated to integrating and extending parachain capabilities to standalone Substrate chains.`}
   linkText={`Parachains`}
-  link={`/how-to-guides/v3/parachains`}
+  link={`/how-to-guides/parachains`}
   
 />
 <RelatedMaterialBlock
   text={`Guides relating to using tools for getting your chain ready for production or integrate ways to interact with
   your runtime.`}
   linkText={`Tools`}
-  link={`/how-to-guides/v3/tools`}
+  link={`/how-to-guides/tools`}
 />

--- a/v3/how-to-guides/index.mdx
+++ b/v3/how-to-guides/index.mdx
@@ -54,8 +54,7 @@ specific goal they want to achieve. Learn more about contributing to these guide
   
 />
 <RelatedMaterialBlock
-  text={`Guides relating to using tools for getting your chain ready for production or integrate ways to interact with
-  your runtime.`}
+  text={`Guides for tools that are not included out-of-the-box to help you managing Substrate chains in production.`}
   linkText={`Tools`}
   link={`/how-to-guides/tools`}
 />

--- a/v3/how-to-guides/index.mdx
+++ b/v3/how-to-guides/index.mdx
@@ -49,7 +49,7 @@ specific goal they want to achieve. Learn more about contributing to these guide
   link={`/how-to-guides/consensus`}
 />
 <RelatedMaterialBlock
-  text={`All things releated to integrating and extending parachain capabilities to standalone Substrate chains.`}
+  text={`All things related to integrating and extending standalone Substrate chains to parachains.`}
   linkText={`Parachains`}
   link={`/how-to-guides/parachains`}
   

--- a/v3/how-to-guides/index.mdx
+++ b/v3/how-to-guides/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to How-to-guides
+title: Substrate How-to guides
 slug: /how-to-guides/v3
 version: 3.0 
 section: how to guides
@@ -7,114 +7,56 @@ category: overview
 hideNav: true
 ---
 
-## Contribution Guidelines
+Substrate how-to guides are in-depth guides developers with some prior knowledge of Substrate and a 
+specific goal they want to achieve. Learn more about contributing to these guides [here](/v3/contribute/how-to-guides).
 
-### Prelude
+## Browse Categories
 
-Each guide contains various links to the [knowledge base](/v3). Most beginner guides link to other intermediate or advanced guides that use the foundations from the more basic guides they build on. In this way, this book aims to become a modular and extensible framework that:
-
-- Can expand overtime, by virtue of the ease for contributors to integrate new content that follows these linking guidelines and structure.
-- Provides an indispensible collection of guides for developers of all levels building with Substrate.
-- Connects related resources from the developer hub, including documentation and knowledgebase article.
-
-### Requirements
-
-The following points touch on the approach for building content for the Substrate How-to Guides ressource. Each is a point is requirement that must be taken into account for contributors creating new guides.
-
-- **Modularity**. Each piece needs to be a standalone guide that has a well-defined and useful focus. Anything external to that mustbe linked in a way that they can adapt to change. Why? They need to be able to handle changes to Substrate in a way that offers a path of least resistance when implementing those changes.
-
-- **Linking**. How-to guides are meant to be focused and in-depth. Any background knowledge or additional references must link readers to other developer hub ressources.
-
-- **Examples**. This is the part for _"examples on how to actually put this guide to use or where can I see it put to use"_. Each example links to some existing codebase or pallet. If new code was created for the guide, this should be pushed to the `example-code` folder at the top of this directory.
-
-- **References.** At the end of each recipe, developers can see a list of related ressources. Here is where all additional related Knowledgebase links go; Rust docs; as well as links to any other related guides.
-
-- **Avoid repetition.** If there's something that needs to be included in one guide and can be abstracted to a completely separate guide, abstract it and link to it instead of repeating that content. This ties into the modularity aspect too.
-
-### Template
-
-Each guide **must** follow the following structure, taking into account all requirements from above:
-
----
-
-<Objectives
-  data={[
-    {
-      title: 'Title',
-      description:
-        "The guide's intentions should be clear by just reading the title.",
-    },
-    {
-      title: 'Goal',
-      description: 'What specific goal will this guide achieve?',
-    },
-    {
-      title: 'Use Cases',
-      description:
-        'What practical use cases can this guide be applied to? This can be general, e.g. "implementing a second currency for users to pay fees in" or specific, for e.g. "a runtime migration from a `Vec<u32>` to SomeStruct ". It is likely that the more advanced the guide, the more specific its use cases will be. If more than one, use a bulleted list. Otherwise, one phrase.',
-    },
-    {
-      title: 'Overview',
-      description:
-        'A brief overview of why this is a useful guide and what concepts it uses. This is a good place to link to other devhub ressources, including other guides, aiming to give the reader the learning background required to understand how this guide can be useful to them.',
-    },
-    {
-      title: 'Steps',
-      description:
-        'What are the steps that will be taken to achieve the goal? Each step should be action driven, with little description, minimal fluff, linking to other docs if needed. Code snippets can help illustrate the steps but should not take over the focus&mdash;i.e "how do I do this", not "what do I do".',
-    },
-    {
-      title: 'Examples',
-      description:
-        'Code-based examples that make use of this guide. This shows at least one reference of what this guide covers with a working example.This could be a reference to some existing codebase within Substrate or not; or new code that lives in the how-to guide repo.',
-    },
-    {
-      title: 'Resources',
-      description:
-        'A bulleted list of links to similar guides; other devhub ressources; and related material. For example, other how-to guides; tutorials; knowledgebase articles; or Rust docs.',
-    },
-  ]}
+<RelatedMaterialBlock
+  text={`Learn the simple patterns that runtime engineers know inside out. These guides cover the basics 
+  that will help you understand more complex topics.`}
+  linkText={`Basics`}
+  link={`/how-to-guides/v3/basics`}
+  />
+<RelatedMaterialBlock
+  text={`A collection of guides that cover common concepts for building pallets using FRAME, with specific use cases to 
+  give meaningful context to each guide.`}
+  linkText={`Pallet Design`}
+  link={`/how-to-guides/v3/pallet-design`}
+  
 />
-
----
-
-<Message
-  type={`green`}
-  title={`Tip`}
-  text=
-    "Copy the markdown template file from
-    [here](https://github.com/substrate-developer-hub/substrate-how-to-guides/blob/main/docs/contribute/how-to-template.md)
-    to easily get started with this template.
-    "
+<RelatedMaterialBlock
+  text={`All guides about benchmarking and weight configurations for runtime engineers.`}
+  linkText={`Weights`}
+  link={`/how-to-guides/v3/weights`}
+  
 />
-
-## Content structure
-
-The structure of Substrate's how-to guides aims to group guides into categories using a keyword tagging system in the
-front-matter of each guide. For example:
-
-**Simple crowdfund.**
-keywords: _runtime, intermediate, pallet design_
-
-The current groupings are to help organize the repository of how-to guide content. They reflect the different
-areas of development within Substrate:
-
-- **Basics**. Where the really simple guides live, those that can be referenced by more complex ones.
-- **Pallet design**. Everything to do with building custom pallets with or without FRAME.
-- **Weights**. Any content that covers configuring weights for specific use cases.
-- **Testing**. A collection of guides for testing.
-- **Storage migrations**. Anything to do with storage migrations.
-- **Consensus**. Client stuff, bridging, node configurations.
-- **Parachains.** _WIP_
-
-### Keywords
-
-_'basics', 'beginner', 'intermediate', 'advanced', 'runtime', 'pallet design', 'weights', 'fees', 'currency', 'testing', 'storage migration', 'node', 'client', 'consensus', 'proof-of-work'_
-
-## FAQ
-
-**What is the difference between a "how-to guide" and a tutorial?**
-
-A **how-to guide** is an in-depth guide intended for someone who is assumed to have prior Substrate knowledge on how to achieve a specific goal. Information inside a guide is only pertinent to achieving that goal. Anything else is irrelevant.
-
-A **tutorial** is a lesson to teach someone how to achieve something assuming they have no prior knowledge on the subject. They contain more details on the subject; cover breadth (vs. how-to guides which cover depth); and can repeat information across other tutorials.
+<RelatedMaterialBlock
+  text={`Guides to cover different use cases for testing pallets and other runtime logic.`}
+  linkText={`Testing`}
+  link={`/how-to-guides/v3/testing`}
+  
+/>
+<RelatedMaterialBlock
+  text={`A collection of guides to help runtime engineers with different types of storage migrations.`}
+  linkText={`Storage Migrations`}
+  link={`/how-to-guides/v3/storage-migrations`}
+  
+/>
+<RelatedMaterialBlock
+  text={`Discover different ways to implement consensus mechanisms in your runtimes.`}
+  linkText={`Consensus`}
+  link={`/how-to-guides/v3/consensus`}
+/>
+<RelatedMaterialBlock
+  text={`All things releated to integrating and extending parachain capabilities to standalone Substrate chains.`}
+  linkText={`Parachains`}
+  link={`/how-to-guides/v3/parachains`}
+  
+/>
+<RelatedMaterialBlock
+  text={`Guides relating to using tools for getting your chain ready for production or integrate ways to interact with
+  your runtime.`}
+  linkText={`Tools`}
+  link={`/how-to-guides/v3/tools`}
+/>


### PR DESCRIPTION
This creates a top-level category view for How-to guides. I've removed the content that was there previously because that is covered in #122. 

Closes #106.