### PR TITLE
Fix URLs 

### DIFF
--- a/static/assets/tutorials/node-metrics/substrate-node-template-metrics.json
+++ b/static/assets/tutorials/node-metrics/substrate-node-template-metrics.json
@@ -48,7 +48,7 @@
       }
     ]
   },
-  "description": "Grafana dashboard for substrate template metrics. Instructions on use: https://substrate.dev/docs/en/tutorials/visualize-node-metrics/",
+  "description": "Grafana dashboard for substrate template metrics. Instructions on use: https://docs.substrate.io/tutorials/v3/node-metrics#visualizing-prometheus-metrics-with-grafana",
   "editable": true,
   "gnetId": 11784,
   "graphTooltip": 0,

--- a/v3/docs/01-getting-started/a-overview/index.mdx
+++ b/v3/docs/01-getting-started/a-overview/index.mdx
@@ -73,7 +73,7 @@ Substrate allows developers to make choices between technical freedom and ease o
 ### Examples
 
 - Follow our [tutorials](/tutorials/v3) to learn about building and running blockchains with Substrate and FRAME.
-- Refer to [Substrate Recipes](https://substrate.dev/recipes) to find complete working examples that demonstrate
+- Refer to our [how-to guides](/how-to-guides/v3) to find working code based examples that demonstrate
   solutions to common problems.
 
 ### References

--- a/v3/docs/03-runtime/b-macros/index.mdx
+++ b/v3/docs/03-runtime/b-macros/index.mdx
@@ -224,7 +224,7 @@ Required, to implement a pallet's dispatchables. Each dispatchable must:
 
 **What it Does**
 
-[Extrinsics](https://substrate.dev/docs/en/knowledgebase/learn-substrate/extrinsics) can use calls to
+[Extrinsics](/v3/concepts/extrinsics) can use calls to
 trigger specific logic. Calls can also be used in on-chain governance, demonstrated by the democracy
 pallet where calls can be voted on.
 `#[pallet::call]` allows to create dispatchable functions which will generate associated items

--- a/v3/docs/03-runtime/e-storage/index.mdx
+++ b/v3/docs/03-runtime/e-storage/index.mdx
@@ -496,17 +496,16 @@ Read [the advanced storage documentation](/v3/advanced/storage).
 
 ### Examples
 
-Check out the Substrate Recipes covering various topics on storage:
+Check out some guides covering various topics on storage:
 
-- [Storage Maps](https://substrate.dev/recipes/storage-maps.html)
-- [Caching Storage Calls](https://substrate.dev/recipes/cache.html)
-- [Using Vectors](https://substrate.dev/recipes/vec-set.html)
-- [Using Maps](https://substrate.dev/recipes/map-set.html)
+- [Using a Storage Map](/how-to-guides/v3/basics/mint-token)
+- [Structs in storage](/how-to-guides/v3/pallet-design/storage-value)
+- [Storage migration](/how-to-guides/v3/storage-migrations/basics)
 
 ### References
 
 - Visit the reference docs for the
-  [`decl_storage!` macro](/rustdocs/latest/frame_support/macro.decl_storage.html)
+  [#[frame_support::pallet] macro](/rustdocs/latest/frame_support/attr.pallet.html#storage-palletstorage-optional)
   for more details about the available storage declarations.
 
 - Visit the reference docs for

--- a/v3/docs/03-runtime/k-testing/index.mdx
+++ b/v3/docs/03-runtime/k-testing/index.mdx
@@ -130,7 +130,7 @@ time dependent changes.
 
 A simple way of doing this increments the System module's block number between `on_initialize` and
 `on_finalize` calls from all modules with `System::block_number()` as the sole input. While it is
-important for runtime code to [cache calls](https://substrate.dev/recipes/cache.html) to storage or
+important for runtime code to cache calls to storage or
 the system module, the test environment scaffolding should prioritize readability to facilitate
 future maintenance.
 

--- a/v3/docs/03-runtime/l-randomness/index.mdx
+++ b/v3/docs/03-runtime/l-randomness/index.mdx
@@ -81,7 +81,7 @@ _all_ pallet's that consume its randomness.
 
 ### Examples
 
-- Explore the [Recipe about Randomness](https://substrate.dev/recipes/randomness.html).
+- Explore this [guide about implementing Randomness](/how-to-guides/v3/pallet-design/randomness).
 
 ### References
 

--- a/v3/docs/03-runtime/n-pallet-coupling/index.mdx
+++ b/v3/docs/03-runtime/n-pallet-coupling/index.mdx
@@ -102,8 +102,8 @@ impl my_pallet::Config for Runtime {
 ```
 
 `Balances`, which is specified in `construct_runtime!` macro, is of type
-[`pallet_balances`](https://substrate.dev/rustdocs/latest/pallet_balances)
-that [implements `Currency` trait](https://substrate.dev/rustdocs/latest/pallet_balances/index.html#implementations-1).
+[`pallet_balances`](/rustdocs/latest/pallet_balances)
+that [implements `Currency` trait](/rustdocs/latest/pallet_balances/index.html#implementations-1).
 
 By now we have closed the loop and provide on implementation to `Currency<AccountId>` trait.
 

--- a/v3/docs/03-runtime/p-smart-contracts/a-overview/index.mdx
+++ b/v3/docs/03-runtime/p-smart-contracts/a-overview/index.mdx
@@ -158,7 +158,7 @@ decisions on which approach to use based on different situations.
   type={`green`}
   title={`Further learning`}
   text={`If you are building on Polkadot, you can also
-  [deploy smart contracts on its parachain](https://wiki.polkadot.network/docs/en/build-smart-contracts). Check [here](https://wiki.polkadot.network/docs/en/build-build-with-polkadot#what-is-the-difference-between-building-a-parachain-a-parathread-or-a-smart-contract) for
+  [deploy smart contracts on its parachain](https://wiki.polkadot.network/docs/en/build-smart-contracts). Check [here](https://wiki.polkadot.network/docs/build-build-with-polkadot#what-is-the-difference-between-building-a-parachain-a-parathread-or-a-smart-contract) for
   a comparison between developing on a parachain, parathread, and smart contract.`}
 />
 
@@ -372,7 +372,7 @@ and other FRAME pallets to your blockchain's runtime.
 - Follow a
   [this guide](/how-to-guides/v3/pallet-design/contracts-pallet) to learn how to add the Contracts pallet to your FRAME runtime.
 - Learn how to
-  [start developing with the Contracts pallet and ink!](https://substrate.dev/substrate-contracts-workshop/#/).
+  [start developing with the Contracts pallet and ink!](/tutorials/v3/ink-workshop/pt1).
 
 ### References
 

--- a/v3/docs/07-advanced/d-block-import/index.mdx
+++ b/v3/docs/07-advanced/d-block-import/index.mdx
@@ -79,9 +79,9 @@ Polkadot's block import pipeline consists of a `BabeBlockImport`, which wraps a
 
 ## Learn More
 
-Several of the Recipes' nodes demonstrate the block import pipeline:
+Have a look at these guides that cover the block import pipeline:
 
-- [Basic PoW](https://substrate.dev/recipes/basic-pow.html) - the import pipeline includes
+- [Basic PoW](/how-to-guides/v3/consensus/pow) - the import pipeline includes
   PoW and the client
-- [Hybrid Consensus](https://substrate.dev/recipes/hybrid-consensus.html) - the import
+- [Hybrid Consensus](/how-to-guides/v3/consensus/hybrid-pos-pow) - the import
   pipeline is PoW, then Grandpa, then the client

--- a/v3/docs/Examples/Components/index.mdx
+++ b/v3/docs/Examples/Components/index.mdx
@@ -52,7 +52,7 @@ with the Ethereum EVM Solidity compiler`}
     configuration in this [basic guide on weights](./basic-tx-weight-calculations).
   - **Origins.** One assumption this guide makes is that the origin will always be the sudo user.
     Origins are a powerful capability in Substrate. Learn more about how they work
-    [here](https://substrate.dev/docs/en/knowledgebase/runtime/origin).
+    [here](/v3/runtime/origins).
   `}
 />
 
@@ -106,7 +106,7 @@ Use this component if you'd like to have some key objectives defined in the begi
 
 [Tutorials](/tutorials)
 
-Here is some text <ExternalLink url="https://www.substrate.dev">Substrate Developers Hub</ExternalLink> and is some more text.
+Here is some text <ExternalLink url="https://docs.substrate.io">Substrate Developers Hub</ExternalLink> and is some more text.
 
 ## Tutorial Components
 

--- a/v3/how-to-guides/01-basics/a-pallet-integration/index.mdx
+++ b/v3/how-to-guides/01-basics/a-pallet-integration/index.mdx
@@ -150,7 +150,7 @@ std = [
     FRAME Timestamp Pallet in Crates.io{' '}
   </ExternalLink>
 
-[mock-runtime]: https://substrate.dev/docs/en/knowledgebase/runtime/tests#mock-runtime-environment
+[mock-runtime]: /v3/runtime/testing#mock-runtime-environment
 [timestamp-frame]: https://github.com/paritytech/substrate/blob/master/bin/node/runtime/src/lib.rs#L413-L422
 [timestamp-rustdocs]: /rustdocs/latest/pallet_timestamp/pallet/trait.Config.html#associated-types
 [template-frame]: https://github.com/substrate-developer-hub/substrate-node-template/blob/master/pallets/template/src/lib.rs#L1-L107

--- a/v3/how-to-guides/01-basics/d-genesis-config/index.mdx
+++ b/v3/how-to-guides/01-basics/d-genesis-config/index.mdx
@@ -20,7 +20,7 @@ difficulty: 1
   data={[
     {
       title: 'Goal',
-      description: `Learn how to customize a chain's genesis configuration for the [balances pallet](https://substrate.dev/docs/en/knowledgebase/runtime/frame#balances).`,
+      description: `Learn how to customize a chain's genesis configuration for the [balances pallet](/rustdocs/latest/pallet_balances/index.html).`,
     },
     {
       title: 'Use Cases',
@@ -89,7 +89,6 @@ pallet_balances: Some(BalancesConfig {
 
 - [`BalancesConfig`][balances-config-rustdocs]
 
-[balances-frame]: https://substrate.dev/docs/en/knowledgebase/runtime/frame#balances
 [balances-config-rustdocs]: /rustdocs/latest/node_template_runtime/type.BalancesConfig.html
 [genesis-config-rustdocs]: /rustdocs/latest/pallet_balances/struct.GenesisConfig.html
 [node-template-chainspec]: https://github.com/substrate-developer-hub/substrate-node-template/blob/master/node/src/chain_spec.rs#L142-L144

--- a/v3/how-to-guides/01-basics/f-mint-token/index.mdx
+++ b/v3/how-to-guides/01-basics/f-mint-token/index.mdx
@@ -38,8 +38,8 @@ difficulty: 1
       description:
         `This guide will step you through an effective way to mint a token by leveraging the primitive capabilities that
 		 [StorageMap](/rustdocs/latest/frame_support/storage/trait.StorageMap.html) gives us. To achieve this, this "primitive" 
-		 approach uses the [blake2_128_concat](https://substrate.dev/docs/en/knowledgebase/runtime/storage#hashing-algorithms) 
-		 \`hasher\` to map balances to account IDs, similar to how the [Balances][balances-frame] pallet makes use of it to store 
+		 approach uses the [blake2_128_concat](/v3/runtime/storage#hashing-algorithms) 
+		 \`hasher\` to map balances to account IDs, similar to how the [Balances](/rustdocs/latest/pallet_balances/index.html) pallet makes use of it to store 
 		 and keep track of account balances.
 	    `,
     },
@@ -174,7 +174,7 @@ Refer to [this guide](../pallet-integration) if you’re not yet familiar with t
     configuration in this [basic guide on weights](../weights).
   - **Origins.** One assumption this guide makes is that the origin will always be the sudo user.
     Origins are a powerful capability in Substrate. Learn more about how they work
-    [here](https://substrate.dev/docs/en/knowledgebase/runtime/origin).
+    [here](/v3/runtime/origins).
   `}
 />
 
@@ -193,6 +193,5 @@ Refer to [this guide](../pallet-integration) if you’re not yet familiar with t
 
 - [Deposit event method][deposit-event-rustdocs]
 
-[balances-frame]: https://substrate.dev/docs/en/knowledgebase/runtime/frame#balances
-[events-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/events
+[events-kb]: /v3/runtime/events-and-errors
 [deposit-event-rustdocs]: /rustdocs/latest/frame_system/pallet/struct.Pallet.html#method.deposit_event

--- a/v3/how-to-guides/01-basics/g-weights/index.mdx
+++ b/v3/how-to-guides/01-basics/g-weights/index.mdx
@@ -35,11 +35,11 @@ difficulty: 1
       title: 'Overview',
       description:
         `Weights are an important part of Substrate development as they provide information about what the maximum cost a function can 
-        be in terms of the block size it will take up. This way, the [weighting system](https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight) 
+        be in terms of the block size it will take up. This way, the [weighting system](/v3/concepts/weight) 
         checks what the cost will be before 
         a function is executed. As runtime engineers, we care a lot about weights. Not only do they help add security checks around the 
         functions we create, but they also force us to think about the computational ressources consumed by a transaction. From that, we 
-        can figure out [what fees to charge](https://substrate.dev/docs/en/knowledgebase/runtime/fees) users.
+        can figure out [what fees to charge](/v3/runtime/weights-and-fees) users.
         This guide will cover how to calculate the maximum weight for a dispatch call; calculate the actual weight after execution; and
         reimburse the difference.
         Here's an overview of the traits we'll be implementing:
@@ -106,8 +106,8 @@ Ok(Pays::Yes.into())
 
 #### Knowledgebase
 
-- [Transaction Weights](https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight)
-- [Transaction Fees Knowledgebase](https://substrate.dev/docs/en/knowledgebase/runtime/fees)
+- [Transaction Weights](/v3/concepts/weight)
+- [Transaction Fees Knowledgebase](/v3/runtime/weights-and-fees)
 
 #### Rust docs
 

--- a/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
@@ -115,7 +115,7 @@ in FRAME's [Democracy pallet](https://github.com/paritytech/substrate/blob/maste
 - the use of `WeightInfo` in all FRAME pallets, such as the 
 the [Identity pallet](https://github.com/paritytech/substrate/blob/master/frame/identity/src/lib.rs#L149-L151) and its use of its 
 [specific weighting methods](https://github.com/paritytech/substrate/blob/master/frame/identity/src/weights.rs#L46-L64) 
-- the [`KeyOwnerProofSystem` trait](https://substrate.dev/rustdocs/latest/frame_support/traits/trait.KeyOwnerProofSystem.html) 
+- the [`KeyOwnerProofSystem` trait](/rustdocs/latest/frame_support/traits/trait.KeyOwnerProofSystem.html) 
 [used in `pallet_granpa`](https://github.com/paritytech/substrate/blob/master/frame/grandpa/src/lib.rs#L106)
 
 ## Resources

--- a/v3/how-to-guides/03-weights/a-calculate-fees/index.mdx
+++ b/v3/how-to-guides/03-weights/a-calculate-fees/index.mdx
@@ -99,8 +99,8 @@ impl pallet_transaction_payment::Config for Runtime {
 
 #### Knowledgebase
 
-- [Weights](https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight)
-- [Transaction Weights and Fees](https://substrate.dev/docs/en/knowledgebase/runtime/fees)
+- [Weights](/v3/concepts/weight)
+- [Transaction Weights and Fees](/v3/runtime/weights-and-fees)
 
 #### Rust docs
 

--- a/v3/how-to-guides/04-testing/a-basic-pallet-testing/index.mdx
+++ b/v3/how-to-guides/04-testing/a-basic-pallet-testing/index.mdx
@@ -167,4 +167,4 @@ cargo test
 
 [template-node-mock-rs]: https://github.com/substrate-developer-hub/substrate-node-template/blob/467927bda05a56dfe57690aec93ff504a6009daa/pallets/template/src/mock.rs#L1-L61
 [template-node-mock-rs]: https://github.com/substrate-developer-hub/substrate-node-template/blob/467927bda05a56dfe57690aec93ff504a6009daa/pallets/template/src/tests.rs#L1-L23
-[mock-runtime]: https://substrate.dev/docs/en/knowledgebase/runtime/tests#mock-runtime-environment
+[mock-runtime]: /v3/runtime/testing#mock-runtime-environment

--- a/v3/how-to-guides/06-consensus/a-pow/index.mdx
+++ b/v3/how-to-guides/06-consensus/a-pow/index.mdx
@@ -139,7 +139,7 @@ Follow the pattern from the previous step to create `new_light`.
 [partialcomponents-rustdocs]: /rustdocs/latest/sc_service/struct.PartialComponents.html
 [powblockimport-rustdocs]: /rustdocs/latest/sc_consensus_pow/struct.PowBlockImport.html
 [powblockimport-new-rustdocs]: /rustdocs/latest/sc_consensus_pow/struct.PowBlockImport.html#method.new_full
-[inherents-kb]: https://substrate.dev/docs/en/knowledgebase/learn-substrate/extrinsics#inherents
+[inherents-kb]: /v3/concepts/extrinsics#inherents
 [inherents-rustdocs]: /rustdocs/latest/sp_inherents/struct.InherentDataProviders.html
 [lightclient-parity]: https://www.parity.io/what-is-a-light-client/
 [pow-rustdocs]: /rustdocs/latest/sc_consensus_pow/trait.PowAlgorithm.html

--- a/v3/how-to-guides/06-consensus/b-hybrid-pow-pos/index.mdx
+++ b/v3/how-to-guides/06-consensus/b-hybrid-pow-pos/index.mdx
@@ -178,6 +178,6 @@ task_manager.spawn_essential_handle().spawn_blocking(
 
 [powblockimport-rustdocs]: /rustdocs/latest/sc_consensus_pow/struct.PowBlockImport.html
 [powblockimport-new-rustdocs]: /rustdocs/latest/sc_consensus_pow/struct.PowBlockImport.html#method.new_full
-[inherents-kb]: https://substrate.dev/docs/en/knowledgebase/learn-substrate/extrinsics#inherents
+[inherents-kb]: /v3/concepts/extrinsics#inherents
 [inherents-rustdocs]: /rustdocs/latest/sp_inherents/struct.InherentDataProviders.html
 [pow-rustdocs]: /rustdocs/latest/sc_consensus_pow/trait.PowAlgorithm.html

--- a/v3/how-to-guides/07-parachains/b-setup/index.mdx
+++ b/v3/how-to-guides/07-parachains/b-setup/index.mdx
@@ -64,7 +64,7 @@ Use benchmarking to verify that your runtime weights are correct.
 <Message
   type={`green`}
   title={`Tip`}
-  text={`Refer to this [knowledgebase article](https://substrate.dev/docs/en/knowledgebase/runtime/benchmarking) on benchmarking for additional information.`}
+  text={`Refer to this [knowledgebase article](/v3/runtime/benchmarking) on benchmarking for additional information.`}
 />
 
 #### Customize weights
@@ -124,4 +124,4 @@ It is less favorable to perform storage upgrades for large runtimes. In these ca
 
 - [Benchmarking][benchmarking-kb]
 
-[benchmarking-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/benchmarking
+[benchmarking-kb]: /v3/runtime/benchmarking

--- a/v3/how-to-guides/07-parachains/d-register/index.mdx
+++ b/v3/how-to-guides/07-parachains/d-register/index.mdx
@@ -34,11 +34,11 @@ To register your parachain you need to provide your ParaID, genesis state and
 your compressed WASM validation logic.
 
 - Generate
-  [parachain Genesis state](https://substrate.dev/cumulus-workshop/#/en/3-parachains/1-launch?id=generate-parachain-genesis-state)
-- [Obtain WASM runtime validation logic](https://substrate.dev/cumulus-workshop/#/en/3-parachains/1-launch?id=obtain-wasm-runtime-validation-function).
+  [parachain Genesis state](/tutorials/v3/cumulus-workshop/pt2#3-generate-parachain-genesis-state)
+- [Obtain WASM runtime validation logic](/tutorials/v3/cumulus-workshop/pt2#4-obtain-wasm-runtime-validation-function).
   maximum size of the WASM blob is 750 kilobytes on Kusama
 - Compress WASM validation logic
-- [Register the parachain](https://substrate.dev/cumulus-workshop/#/en/3-parachains/2-register?id=parachain-registration).
+- [Register the parachain](/tutorials/v3/cumulus-workshop/pt2#parachain-registration).
   This transaction requires a deposit. The amount of the deposit depends on the
   size of the WASM blob and the genesis states.
 - Check and calculate the exact formulas for deposit calculation for
@@ -48,5 +48,5 @@ your compressed WASM validation logic.
 
 ## Examples
 
-[register-paraid]: https://substrate.dev/substrate-how-to-guides/docs/parachains/c-registration/register-paraid
+[register-paraid]: /tutorials/v3/cumulus-workshop/pt2#1-reserve-a-para-id
 [crowdloan-paraid]: https://wiki.polkadot.network/docs/learn-crowdloans

--- a/v3/how-to-guides/07-parachains/e-start-collator-node/index.mdx
+++ b/v3/how-to-guides/07-parachains/e-start-collator-node/index.mdx
@@ -68,11 +68,11 @@ become a collator. Use the democracy pallet to elect these members and define th
 
 ### 2. Starting a collator node
 
-Refer to [this guide](https://substrate.dev/cumulus-workshop/#/en/3-parachains/1-launch?id=start-the-collator-node) to start and set up a collator node.
+Refer to [this guide](/tutorials/v3/cumulus-workshop/pt2#5-start-the-collator-node) to start and set up a collator node.
 
 ### 3. Adding collators
 
-Refer to [this instruction](https://substrate.dev/cumulus-workshop/#/en/3-parachains/4-more-nodes?id=start-the-second-collator) to add more collators.
+Refer to [this instruction](/tutorials/v3/cumulus-workshop/pt2#1-start-the-second-collator) to add more collators.
 
 ## Examples
 

--- a/v3/how-to-guides/07-parachains/f-start-testnet/index.mdx
+++ b/v3/how-to-guides/07-parachains/f-start-testnet/index.mdx
@@ -57,4 +57,4 @@ cargo run -- \
 
 #### Other 
 
-- [Polkadot Wiki on Using Rococo](https://wiki.polkadot.network/docs/build-parachains-rococo)
+- [Polkadot Wiki on Using Rococo](https://wiki.polkadot.network/docs/build-pdk#testing-a-parachain-rococo-testnet)

--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -327,7 +327,7 @@ To implement this, replace `#[pallet::event]` with:
 ```rust
 	// Pallets use events to inform users when important changes are made.
 	// Event documentation should end with an array that provides descriptive names for parameters.
-	// https://substrate.dev/docs/en/knowledgebase/runtime/events
+	// https://docs.substrate.io/v3/runtime/events-and-errors
 	#[pallet::event]
 	#[pallet::metadata(T::AccountId = "AccountId")]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -427,7 +427,7 @@ To implement this, replace the `#[pallet::call]` line with:
 
                 // Check that the extrinsic was signed and get the signer.
                 // This function will return an error if the extrinsic is not signed.
-                // https://substrate.dev/docs/en/knowledgebase/runtime/origin
+                // https://docs.substrate.io/v3/runtime/origins
                 let sender = ensure_signed(origin)?;
 
                 // Verify that the specified proof has not already been claimed.
@@ -452,7 +452,7 @@ To implement this, replace the `#[pallet::call]` line with:
             ) -> DispatchResultWithPostInfo {
                 // Check that the extrinsic was signed and get the signer.
                 // This function will return an error if the extrinsic is not signed.
-                // https://substrate.dev/docs/en/knowledgebase/runtime/origin
+                // https://docs.substrate.io/v3/runtime/origins
                 let sender = ensure_signed(origin)?;
 
                 // Verify that the specified proof has been claimed.
@@ -768,7 +768,7 @@ experience short and satisfying. However, we want you to keep learning!
 
 #### Learn more
 To learn more about building your own pallets, explore the
-[Substrate Recipes](https://substrate.dev/recipes/) and the [How-to Guides](/how-to-guides)
+[FRAME documentation](/v3/runtime/FRAME) and the [how-to guides](/how-to-guides).
 
 Complete the [Add a Pallet](/tutorials/v3/add-a-pallet/) tutorial to learn how to extend the Node Template with
 additional capabilities from Substrate's set of

--- a/v3/tutorials/10-frontier-workshop/index.mdx
+++ b/v3/tutorials/10-frontier-workshop/index.mdx
@@ -76,7 +76,7 @@ https://github.com/substrate-developer-hub/frontier-node-template/ .
 
 The development [chain spec](https://github.com/paritytech/frontier/blob/master/template/node/src/chain_spec.rs) included with this project defines a genesis
 block that has been pre-configured with an EVM account for
-[Alice](https://substrate.dev/docs/en/knowledgebase/integrate/subkey#well-known-keys). When
+[Alice](/v3/tools/subkey#well-known-keys). When
 [a development chain is started](https://github.com/substrate-developer-hub/substrate-node-template#run),
 Alice's EVM account will be funded with a large amount of Ether. The
 [Polkadot UI](https://polkadot.js.org/apps/#?rpc=ws://127.0.0.1:9944) can be used to see the details
@@ -190,8 +190,8 @@ runtime APIs & RPCs.
 
 Further reading:
 
-- [Recipe about Runtime APIs](https://substrate.dev/recipes/runtime-api.html)
-- [Recipe about Custom RPCs](https://substrate.dev/recipes/custom-rpc.html)
+- [Runtime APIs](/v3/concepts/runtime#runtime-apis)
+- [Recipe about Custom RPCs](/v3/runtime/custom-rpcs)
 - RPCs in Frontier: [fc-rpc](https://github.com/paritytech/frontier/tree/master/client/rpc)
   and [fc-rpc-core](https://github.com/paritytech/frontier/blob/master/client/rpc-core/)
 

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -377,7 +377,7 @@ To do this we'll use [`StorageValue`][storagevalue-rustdocs] from Substrate's
 [storage API][storage-api-rustdocs] which is a trait that depends on the [storage macro][storage-macro-kb].
 
 All that means for our purposes is that for any storage item we want to declare, we must include the
-`#[pallet::storage]`  macro beforehand. Learn more about declaring storage items [here](https://substrate.dev/docs/en/knowledgebase/runtime/storage#declaring-storage-items).
+`#[pallet::storage]`  macro beforehand. Learn more about declaring storage items [here](/v3/runtime/storage#declaring-storage-items).
 
 In `pallets/kitties/src/lib.rs`, replace the ACTION line with:
 
@@ -420,16 +420,16 @@ various patterns for:
 - Declaring a single value \`u64\` storage item.
   `} />
 
-[installation]: https://substrate.dev/docs/en/knowledgebase/getting-started/
+[installation]: /v3/getting-started/installation
 [substrate-node-template]: https://github.com/substrate-developer-hub/substrate-node-template
-[pallets-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/pallets
-[macros-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/macros#frame-v2-macros-and-attributes
-[storagevalue-rustdocs]: https://substrate.dev/rustdocs/v3.0.0/frame_support/storage/trait.StorageValue.html
-[storage-api-rustdocs]: https://substrate.dev/rustdocs/v3.0.0/frame_support/storage/index.html
+[pallets-kb]: /v3/runtime/frame#pallets
+[macros-kb]: /v3/runtime/macros#frame-macros-and-attributes
+[storagevalue-rustdocs]: /rustdocs/latest/frame_support/storage/trait.StorageValue.html
+[storage-api-rustdocs]: /rustdocs/latest/frame_support/storage/index.html
 [template-code]: https://github.com/substrate-developer-hub/substrate-how-to-guides/tree/main/static/code/kitties-tutorial
-[runtime-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/
+[runtime-kb]: /v3/concepts/runtime
 [kickstart-tool]: https://github.com/Keats/kickstart
-[storage-macro-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/macros#palletstorage
+[storage-macro-kb]: /v3/runtime/macros#palletstorage
 
 
 ## Uniqueness, Custom Types, and Storage Maps
@@ -860,18 +860,18 @@ learnt:\n\n
 `}/>
 
 [default-rustdocs]: https://doc.rust-lang.org/std/default/trait.Default.html
-[randomness-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/traits/trait.Randomness.html
-[hash-rustdocs]: https://substrate.dev/rustdocs/latest/sp_runtime/traits/trait.Hash.html
-[h256-rustdocs]: https://substrate.dev/rustdocs/latest/sp_core/struct.H256.html
-[randomness-collective-flip-frame]: https://substrate.dev/rustdocs/latest/pallet_randomness_collective_flip/index.html
-[nonce-rustdocs]: https://substrate.dev/rustdocs/latest/frame_system/struct.AccountInfo.html#structfield.nonce
-[2x64-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/struct.Twox64Concat.html
-[prelude-traits-rustdocs]: https://substrate.dev/rustdocs/latest/sp_std/prelude/index.html#traits
+[randomness-rustdocs]: /rustdocs/latest/frame_support/traits/trait.Randomness.html
+[hash-rustdocs]: /rustdocs/latest/sp_runtime/traits/trait.Hash.html
+[h256-rustdocs]: /rustdocs/latest/sp_core/struct.H256.html
+[randomness-collective-flip-frame]: /rustdocs/latest/pallet_randomness_collective_flip/index.html
+[nonce-rustdocs]: /rustdocs/latest/frame_system/struct.AccountInfo.html#structfield.nonce
+[2x64-rustdocs]: /rustdocs/latest/frame_support/struct.Twox64Concat.html
+[prelude-traits-rustdocs]: /rustdocs/latest/sp_std/prelude/index.html#traits
 [derive-macro-rust]: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros
-[storage-best-practice-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/storage#best-practices
-[storage-map-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/storage#storage-map
-[storage-value-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/storage#storage-value
-[currency-frame]: https://substrate.dev/rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#associatedtype.Balance
+[storage-best-practice-kb]: /v3/runtime/storage#best-practices
+[storage-map-kb]: /v3/runtime/storage#best-practices#storage-map
+[storage-value-kb]: /v3/runtime/storage#storage-value
+[currency-frame]: /rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#associatedtype.Balance
 
 
 ## Dispatchables, Events, and Errors
@@ -987,7 +987,7 @@ section):
   text={`
 In \`create_kitty\` our return was of type \`DispatchResult\`. Since \`mint()\` is a helper for
 \`create_kitty\`, we don't need to overwrite \`PostDispatchInfo\`, we can use a return type of
-[\`DispatchResult\`](https://substrate.dev/rustdocs/latest/frame_support/dispatch/type.DispatchResult.html)
+[\`DispatchResult\`](/rustdocs/latest/frame_support/dispatch/type.DispatchResult.html)
 &mdash; its unaugmented version.
   `}/>
 
@@ -1050,11 +1050,11 @@ checking for overflow with `check_add()` function.
 
 Once we've done with the check, we proceed with updating our storage items by:
 
-1. Making use of the [`try_mutate`](https://substrate.dev/rustdocs/latest/frame_support/storage/trait.StorageMap.html#tymethod.try_mutate)
+1. Making use of the [`try_mutate`](/rustdocs/latest/frame_support/storage/trait.StorageMap.html#tymethod.try_mutate)
 to update the kitty's owner vector.
 2. Using [`insert`][insert-rustdocs] method provided by Substrate's StorageMap API to store the
 actually Kitty object and associate it with its `kitty_id`.
-3. Using [`put`](https://substrate.dev/rustdocs/latest/frame_support/storage/trait.StorageValue.html#tymethod.put)
+3. Using [`put`](/rustdocs/latest/frame_support/storage/trait.StorageValue.html#tymethod.put)
 provided by StorageValue API to save the latest kitty count.
 
 <Message type='gray' title='Note' text={`
@@ -1296,20 +1296,20 @@ To recap, in this part of the tutorial you've learnt how to:\n
 - Query storage items and chain state using the PolkadotJS Apps UI.
   `}/>
 
-[frame-macros-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/macros#palletcall
-[txn-fees-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/fees
-[weights-kb]: https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight
-[contains-key-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/storage/trait.StorageMap.html#tymethod.contains_key
-[insert-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/storage/trait.StorageMap.html#tymethod.insert
-[storage-value-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/storage/types/struct.StorageValue.html#method.put
-[storagemap-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/storage/types/struct.StorageMap.html#method.insert
+[frame-macros-kb]: /v3/runtime/macros#palletcall
+[txn-fees-kb]: /v3/runtime/weights-and-fees
+[weights-kb]: /v3/concepts/weight
+[contains-key-rustdocs]: /rustdocs/latest/frame_support/storage/trait.StorageMap.html#tymethod.contains_key
+[insert-rustdocs]: /rustdocs/latest/frame_support/storage/trait.StorageMap.html#tymethod.insert
+[storage-value-rustdocs]: /rustdocs/latest/frame_support/storage/types/struct.StorageValue.html#method.put
+[storagemap-rustdocs]: /rustdocs/latest/frame_support/storage/types/struct.StorageMap.html#method.insert
 [events-rustdocs]: https://crates.parity.io/frame_support/attr.pallet.html#event-palletevent-optional
-[events-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/events
+[events-kb]: /v3/runtime/events-and-errors
 [polkadotjsapps]: https://polkadot.js.org/apps/#/explorer
-[dispatchresult-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/dispatch/type.DispatchResult.html
-[dispatchable-kb]: https://substrate.dev/docs/en/knowledgebase/getting-started/glossary#dispatch
+[dispatchresult-rustdocs]: /rustdocs/latest/frame_support/dispatch/type.DispatchResult.html
+[dispatchable-kb]: /v3/getting-started/glossary#dispatch
 [extrinsics-kb]:  /v3/concepts/execution#executing-extrinsics
-[errors-kb]: https://substrate.dev/docs/en/knowledgebase/runtime/errors
+[errors-kb]: /v3/runtime/events-and-errors
 
 
 ## Interacting with your Kitties
@@ -1537,7 +1537,7 @@ pub fn transfer_kitty_to(
 }
 ```
 
-Notice the use of [`[#transactional]`](https://substrate.dev/rustdocs/latest/frame_support/attr.transactional.html)
+Notice the use of [`[#transactional]`](/rustdocs/latest/frame_support/attr.transactional.html)
 which we imported at the very beginning of this tutorial. It allows us to write dispatchable
 functions that commit changes to the storage only if the annotated function return `Ok`. Otherwise
 all changes are discarded.
@@ -1567,7 +1567,7 @@ ensure!(T::Currency::free_balance(&buyer) >= bid_price, <Error<T>>::NotEnoughBal
 ```
 
 In a similar vain, we have to verify whether the user has the capacity to receive a Kitty &mdash;
-remember we're using a [`BoundedVec`](https://substrate.dev/rustdocs/latest/frame_support/storage/bounded_vec/struct.BoundedVec.html)
+remember we're using a [`BoundedVec`](/rustdocs/latest/frame_support/storage/bounded_vec/struct.BoundedVec.html)
 that can only hold a fixed number of Kitties, defined in our pallet's `MaxKittyOwned` constant.
 
 ```rust
@@ -1736,7 +1736,7 @@ Complete Part II of this tutorial to:
 [frame-balances-rustdocs]: https://crates.parity.io/frame_support/traits/tokens/currency/trait.Currency.html
 [polkadotjs-ui]: https://polkadot.js.org/apps/#/explorer
 [rust-u8]: https://doc.rust-lang.org/std/primitive.u8.html
-[currency-frame-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/traits/tokens/currency/index.html
-[currency-balances-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#associatedtype.Balance
-[balances-frame]: https://substrate.dev/rustdocs/latest/pallet_balances/index.html
-[currency-transfer-rustdocs]: https://substrate.dev/rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#tymethod.transfer
+[currency-frame-rustdocs]: /rustdocs/latest/frame_support/traits/tokens/currency/index.html
+[currency-balances-rustdocs]: /rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#associatedtype.Balance
+[balances-frame]: /rustdocs/latest/pallet_balances/index.html
+[currency-transfer-rustdocs]: /rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#tymethod.transfer

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -869,7 +869,7 @@ learnt:\n\n
 [prelude-traits-rustdocs]: /rustdocs/latest/sp_std/prelude/index.html#traits
 [derive-macro-rust]: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros
 [storage-best-practice-kb]: /v3/runtime/storage#best-practices
-[storage-map-kb]: /v3/runtime/storage#best-practices#storage-map
+[storage-map-kb]: /v3/runtime/storage/#storage-map
 [storage-value-kb]: /v3/runtime/storage#storage-value
 [currency-frame]: /rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html#associatedtype.Balance
 


### PR DESCRIPTION
Closes #197 and replaces all occurrences of substrate.dev with correct references to new docs.

**Note:** There's one exception: for the [Off-Chain Features](https://docs.substrate.io/v3/concepts/off-chain-features) article, the references to the Recipes are the only guides for OCWs. I held off from removing them for now until we have them as HTGs (ref: https://github.com/substrate-developer-hub/substrate-how-to-guides/issues/15) 