### PR TITLE
Fix NextButton active state mobile

### DIFF
--- a/src/components/DocsComponents/NextButton.tsx
+++ b/src/components/DocsComponents/NextButton.tsx
@@ -12,7 +12,7 @@ export function NextButton({ text, link }: NextButtonProps) {
     <>
       <Link to={link}>
         <div className="md-button group inline-block my-6">
-          <div className="flex items-center justify-center w-80 h-14 rounded bg-substrateGreen transform transition duration-300 ease-in-out group-active:bg-white group-hover:bg-white dark:group-hover:bg-darkBackground border-2 border-transparent group-hover:border-substrateGreen">
+          <div className="flex items-center justify-center w-80 h-14 rounded bg-substrateGreen transform transition duration-300 ease-in-out group-hover:bg-white dark:group-hover:bg-darkBackground border-2 border-transparent group-hover:border-substrateGreen">
             <button className="truncate text-lg text-white dark:text-white px-4 group-hover:text-substrateGreen font-bold focus:outline-none group-active:text-white">
               {intl.formatMessage({ id: 'docs-nav-next' })} - {text}
             </button>


### PR DESCRIPTION
NextButton turns all green when tapped outside text on mobile devices, perhaps because the tap triggers active state of text but not hover state of background.