### PR TITLE
Remove the <ExternalLink> component

### DIFF
--- a/v3/docs/03-runtime/n-pallet-coupling/index.mdx
+++ b/v3/docs/03-runtime/n-pallet-coupling/index.mdx
@@ -7,7 +7,7 @@ category: runtime
 keywords: coupling, pallet design
 ---
 
-In computer science, <ExternalLink url="https://en.wikipedia.org/wiki/Coupling_(computer_programming)">coupling</ExternalLink> 
+In computer science, [coupling](https://en.wikipedia.org/wiki/Coupling_(computer_programming))
 is the degree to which two software modules depend on each other. System designers use the terms high and low coupling to
 describe how computer systems are structured. The term also applies to object oriented programming paradigms, whereby tight 
 coupling is when two groups of classes are dependant on each other, and loose coupling is when a class uses an interface that
@@ -129,7 +129,7 @@ a metric used to examine the overall quality of a software system.
 
 ## Learn more
 
-- Read the <ExternalLink url="https://doc.rust-lang.org/book/ch17-00-oop.html">Object Oriented Programming Features of Rust</ExternalLink> 
-section of the Rust Book
+- Read the Object Oriented Programming Features of Rust section of 
+  the [Rust Book]((https://doc.rust-lang.org/book/ch17-00-oop.html))
 - How-to guides on how to use [loose coupling](/how-to-guides/v3/pallet-design/tight-coupling) and
 [tight coupling](/how-to-guides/v3/pallet-design/loose-coupling) in your runtime

--- a/v3/how-to-guides/01-basics/a-pallet-integration/index.mdx
+++ b/v3/how-to-guides/01-basics/a-pallet-integration/index.mdx
@@ -109,7 +109,7 @@ std = [
 
 #### For external pallets
 
-Assuming the pallet is hosted in <ExternalLink url={'https://crates.parity.io/'}>crates.parity.io</ExternalLink>, adding it to the runtime would look like this:
+Assuming the pallet is hosted in [crates.parity.io](https://crates.parity.io/), adding it to the runtime would look like this:
 
 ```rust
 [dependencies.pallet-external]
@@ -145,10 +145,7 @@ std = [
 
 #### Other
 
-- <ExternalLink url="https://crates.io/crates/pallet-timestamp">
-    {' '}
-    FRAME Timestamp Pallet in Crates.io{' '}
-  </ExternalLink>
+- [FRAME `pallet-timestamp`](https://crates.io/crates/pallet-timestamp)
 
 [mock-runtime]: /v3/runtime/testing#mock-runtime-environment
 [timestamp-frame]: https://github.com/paritytech/substrate/blob/master/bin/node/runtime/src/lib.rs#L413-L422

--- a/v3/how-to-guides/01-basics/b-instantiable-pallets/index.mdx
+++ b/v3/how-to-guides/01-basics/b-instantiable-pallets/index.mdx
@@ -86,9 +86,6 @@ MintToken2: mint_token::<Instance2>::{Module, Call, Storage, Event<T>},
 
 ### Other
 
-- <ExternalLink url="https://doc.rust-lang.org/book/ch10-01-syntax.html">
-    {' '}
-    Rust book on generics{' '}
-  </ExternalLink>
+- Rust book on [generics](https://doc.rust-lang.org/book/ch10-01-syntax.html)
 
 [generics-rust-book]: https://doc.rust-lang.org/book/ch10-01-syntax.html

--- a/v3/how-to-guides/01-basics/e-helper-functions/index.mdx
+++ b/v3/how-to-guides/01-basics/e-helper-functions/index.mdx
@@ -93,15 +93,5 @@ a dispatchable that allows a signed extrinsic to add a value to the existing sto
 
 #### Rust docs
 
-- <ExternalLink
-    url={`https://docs.rs/num/0.4.0/num/traits/trait.CheckedAdd.html`}
-  >
-    {' '}
-    checked_add{' '}
-  </ExternalLink>
-- <ExternalLink
-    url={`https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or`}
-  >
-    {' '}
-    ok_or{' '}
-  </ExternalLink>
+- [`checked_add` in `num` crate](https://docs.rs/num/0.4.0/num/traits/trait.CheckedAdd.html)
+- [`ok_or` in `Option` crate](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or)

--- a/v3/how-to-guides/01-basics/g-weights/index.mdx
+++ b/v3/how-to-guides/01-basics/g-weights/index.mdx
@@ -116,11 +116,7 @@ Ok(Pays::Yes.into())
 
 #### Other
 
-- <ExternalLink
-    url={`https://wiki.polkadot.network/docs/en/learn-transaction-fees`}
-  >
-    Polkadot's Transaction Fees{' '}
-  </ExternalLink>
+- Polkadot's [Transaction Fees](https://wiki.polkadot.network/docs/en/learn-transaction-fees)
 
 [pays-rustdocs]: /rustdocs/latest/frame_support/weights/enum.Pays.html
 [dbweight-rustdocs]: /rustdocs/latest/frame_system/pallet/trait.Config.html#associatedtype.DbWeight

--- a/v3/how-to-guides/02-pallet-design/c-randomness/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/c-randomness/index.mdx
@@ -147,11 +147,7 @@ impl my_pallet::Config for Runtime{
 
 #### Other
 
-- <ExternalLink
-    url={`https://en.wikipedia.org/wiki/Verifiable_random_function`}
-  >
-    Verifiable Random Functions
-  </ExternalLink>
+- [Verifiable Random Functions](https://en.wikipedia.org/wiki/Verifiable_random_function)
 
 [h256-rustdocs]: /rustdocs/latest/sp_core/struct.H256.html
 [rcf-pallet-rustdocs]: /rustdocs/latest/pallet_randomness_collective_flip/index.html

--- a/v3/how-to-guides/05-storage-migrations/a-nicks-migration/index.mdx
+++ b/v3/how-to-guides/05-storage-migrations/a-nicks-migration/index.mdx
@@ -207,7 +207,7 @@ Put the new storage types in a `types.json` which you will need to trigger the m
 
 #### Rust docs
 
-- Rust's <ExternalLink url="https://doc.rust-lang.org/std/option/">Option enum</ExternalLink>
+- [`Option` in Rust](https://doc.rust-lang.org/std/option/)
 - [`frame_support::storage::migration`](/rustdocs/latest/frame_support/storage/migration/index.html) utility docs
 
 [translate-storage-rustdocs]: /rustdocs/latest/frame_support/storage/types/struct.StorageMap.html#method.translate

--- a/v3/how-to-guides/05-storage-migrations/b-steps-with-polkadotjs-apps/index.mdx
+++ b/v3/how-to-guides/05-storage-migrations/b-steps-with-polkadotjs-apps/index.mdx
@@ -53,9 +53,5 @@ Hit _"Submit Sudo Unchecked"_ and sign the transaction to trigger the call.
 
 #### Other
 
-- <ExternalLink url="https://polkadot.js.org/docs/">
-    Polkadot JS documentation
-  </ExternalLink>
-- <ExternalLink url="https://polkadot.js.org/apps/">
-    Polkadot-JS Apps
-  </ExternalLink>
+- [Polkadot JS documentation](https://polkadot.js.org/docs/)
+- Hosted [Polkadot-JS Apps UI](https://polkadot.js.org/apps/)

--- a/v3/how-to-guides/05-storage-migrations/c-migration-tests/index.mdx
+++ b/v3/how-to-guides/05-storage-migrations/c-migration-tests/index.mdx
@@ -78,6 +78,4 @@ fn normal_operation_should_work() {
 
 #### Other
 
-- <ExternalLink url="https://github.com/maxsam4/fork-off-substrate">
-    Fork-off Substrate tool{' '}
-  </ExternalLink>
+- [Fork-off Substrate](https://github.com/maxsam4/fork-off-substrate) tool

--- a/v3/how-to-guides/07-parachains/a-connect-relay/index.mdx
+++ b/v3/how-to-guides/07-parachains/a-connect-relay/index.mdx
@@ -132,8 +132,8 @@ Authoring will begin when the collator is actually **registered on the relay cha
 
 Depending on your target relay chain and authority there, you have options to register. Typically
 for testing you will use `sudo` and for production
-use <ExternalLink url="https://wiki.polkadot.network/docs/learn-auction">parachain auctions</ExternalLink>
-and <ExternalLink url="https://wiki.polkadot.network/docs/learn-crowdloans">crowdloans</ExternalLink>.
+use parachain [auctions](https://wiki.polkadot.network/docs/learn-auction)
+and [crowdloans](https://wiki.polkadot.network/docs/learn-crowdloans).
 
 **This guide presently only covers the sudo testing case.**
 
@@ -148,7 +148,7 @@ pub const fn deposit(items: u32, bytes: u32) -> Balance {}
 ```
 
 This is located in the `runtime/<RELAY CHAIN>/src/constants.rs`
-files <ExternalLink url="https://github.com/paritytech/polkadot/blob/master/runtime/"> in Polkadot</ExternalLink>.
+files [in Polkadot](https://github.com/paritytech/polkadot/blob/master/runtime/).
 
 #### Register Using `sudo`
 
@@ -158,8 +158,8 @@ with on Polkadot and Kusama, but for this tutorial we will do it with `sudo` cal
 
 ##### Option 1: `paraSudoWrapper.sudoScheduleParaInitialize`
 
-- Go to the <ExternalLink url="https://polkadot.js.org/apps/#/explorer">Polkadot Apps UI</ExternalLink>
-  , connecting to your **relay chain**.
+- Go to the [Polkadot Apps UI](https://polkadot.js.org/apps/#/explorer), connecting to your
+  **relay chain**.
 
 - Execute a sudo extrinsic on the relay chain by going to `Developer` -> `sudo` page.
 
@@ -175,8 +175,8 @@ page.
 
 ##### Option 2: `slots.forceLease`
 
-- Go to <ExternalLink url="https://polkadot.js.org/apps/#/explorer">Polkadot Apps UI</ExternalLink>,
-  connecting to your **relay chain**.
+- Go to the [Polkadot Apps UI](https://polkadot.js.org/apps/#/explorer), connecting to your
+  **relay chain**.
 
 - Execute a sudo extrinsic on the relay chain by going to `Developer` -> `sudo` page.
 

--- a/v3/how-to-guides/07-parachains/b-collator-selection/index.mdx
+++ b/v3/how-to-guides/07-parachains/b-collator-selection/index.mdx
@@ -42,7 +42,8 @@ a pallet to implement the logic that best fits your needs.
 
 #### Stake voting
 
-The <ExternalLink url="https://github.com/paritytech/cumulus/blob/master/pallets/collator-selection/src/lib.rs"> `collator-selection` pallet </ExternalLink>
+The Cumulus [`collator-selection`
+pallet](https://github.com/paritytech/cumulus/blob/master/pallets/collator-selection/src/lib.rs)
 is a practical example on implementing stake voting to select collators.
 
 #### Using on-chain governance

--- a/v3/how-to-guides/07-parachains/c-pre-launch/index.mdx
+++ b/v3/how-to-guides/07-parachains/c-pre-launch/index.mdx
@@ -51,13 +51,13 @@ Protocol ID collisions will cause _many_ issues for your nodes!
 />
 
 In order to set a unique protocol ID, change make sure you use some nonce or salt value. This is set
-(for
-the <ExternalLink url="https://github.com/substrate-developer-hub/substrate-parachain-template/"> parachain node template </ExternalLink>
+(for the [parachain node template](https://github.com/substrate-developer-hub/substrate-parachain-template/))
 as a CLI item in `/client/network/src/command.rs`, and passed to extend the `/client/network/src/chain_spec.rs`
 
 All [chain specification](/v3/runtime/chain-specs) files include this item as a field. For example,
-the primary <ExternalLink url="https://github.com/paritytech/polkadot/tree/master/node/service/res"> relay chain runtime chain specs </ExternalLink>
-have unique protocol IDs. For Polkadot:
+the primary [relay chain
+runtime](https://github.com/paritytech/polkadot/tree/master/node/service/res)
+chain specs have unique protocol IDs. For Polkadot:
 
 ```json
 // raw chain spec file in polkadot repo `/node/service/res/polkadot.json`
@@ -69,7 +69,7 @@ have unique protocol IDs. For Polkadot:
 ```
 
 Keep an eye (subscribe)
-to <ExternalLink url="https://github.com/paritytech/substrate/issues/7746"> this issue </ExternalLink>
+to [this issue](https://github.com/paritytech/substrate/issues/7746)
 that will address a better method to safely configure this constant in the future.
 
 ### 2. Memory profiling

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -21,7 +21,7 @@ To ensure the security of the data on the chain and the ongoing progress of the 
 At a high level, a blockchain node consists of the following key components:
 
 - [Storage](/v3/advanced/storage)
-- <ExternalLink url="https://libp2p.io">Peer-to-peer networking</ExternalLink>
+- [Peer-to-peer networking](https://libp2p.io)
 - [Consensus capabilities](/v3/advanced/consensus)
 - Data handling capabilities for external or ["extrinsic"](/v3/concepts/extrinsics) information
 - A [Runtime](/v3/concepts/runtime)
@@ -421,6 +421,6 @@ You can explore these components on your own or may interested to learn more abo
 
 If you've experienced any issues with this tutorial or wanted to provide feedback:
 
-- Ask questions on <ExternalLink url="https://stackoverflow.com/questions/tagged/substrate">Stack Overflow</ExternalLink> using the *substrate* tag.
+- Ask questions on [Stack Overflow tagged *substrate*](https://stackoverflow.com/questions/tagged/substrate).
 
-- Contact <ExternalLink url="https://matrix.to/#/#substrate-technical:matrix.org">Parity on Element</ExternalLink> .
+- Contact the [Substrate community on Element](https://matrix.to/#/#substrate-technical:matrix.org).

--- a/v3/tutorials/06-node-metrics/index.mdx
+++ b/v3/tutorials/06-node-metrics/index.mdx
@@ -15,11 +15,10 @@ relevantSkills:
 
 ## Introduction
 
-Recent versions of Substrate expose metrics, such as how many peers your node is
-connected to, how much memory your node is using, etc. To visualize these
-metrics, you can use tools like <ExternalLink url="https://prometheus.io/">Prometheus</ExternalLink> 
-and <ExternalLink url="https://grafana.com/">Grafana</ExternalLink>. In this tutorial you will learn how to use Grafana and 
-Prometheus to scrape and visualize node metrics.
+Recent versions of Substrate expose metrics, such as how many peers your node is connected to, how
+much memory your node is using, etc. To visualize these metrics, you can use tools like
+[Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/). In this tutorial you will
+learn how to use Grafana and Prometheus to scrape and visualize node metrics.
 
 
 <Message
@@ -263,10 +262,8 @@ in Grafana to get basic information about your node:
 
 ![Grafana Dashboard](../../../src/images/tutorials/06-visualize-node-metrics/grafana.png)
 
-If you create your own, the <ExternalLink url="https://prometheus.io/docs/visualization/grafana/">prometheus docs for
-Grafana</ExternalLink> may be helpful.
-
-<b></b>
+If you create your own,
+the [prometheus docs for Grafana](https://prometheus.io/docs/visualization/grafana/) may be helpful.
 
 If you do create one, consider uploading it to the [community list of
 dashboards](https://grafana.com/grafana/dashboards) and letting the Substrate

--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -725,5 +725,5 @@ within FRAME, see [this example in `substrate`](https://github.com/paritytech/su
 
 #### References
 
-- <ExternalLink url="https://doc.rust-lang.org/stable/cargo/">The Cargo book</ExternalLink>
-- <ExternalLink url="https://rustwasm.github.io/">Rust and WebAssembly</ExternalLink>
+- [The Cargo book](https://doc.rust-lang.org/stable/cargo/)
+- [Rust and WebAssembly](https://rustwasm.github.io/) documentation

--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -141,8 +141,9 @@ flipper
 
 ### 1. Contract Source Code
 
-The ink CLI automatically generates the source code for the "Flipper" contract, which is about the simplest "smart" contract you can build. 
-You can take a sneak peak as to what will come by looking at the <ExternalLink url="https://github.com/paritytech/ink/blob/v3.0.0-rc3/examples/flipper/lib.rs">Flipper Example source code</ExternalLink> .
+The ink CLI automatically generates the source code for the "Flipper" contract, which is about the
+simplest "smart" contract you can build. You can take a sneak peak as to what will come by looking
+at the [Flipper Example](https://github.com/paritytech/ink/blob/v3.0.0-rc3/examples/flipper/lib.rs).
 
 The Flipper contract is nothing more than a `bool` which gets flipped from true to false through the `flip()` function. We won't go deep into the details of this source code because we will be walking you through the steps of building a more advanced contract!
 
@@ -232,8 +233,9 @@ If you look closely at the constructors and messages, you will also notice a `se
 contains a 4-byte hash of the function name and is used to route your contract calls to the correct
 functions.
 
-In the next section we will start a <ExternalLink url="https://github.com/paritytech/substrate-contracts-node">Substrate Smart Contracts node</ExternalLink>
-and configure the <ExternalLink url="https://github.com/paritytech/canvas-ui">Canvas UI</ExternalLink> to interact with it.
+In the next section we will start a
+[Substrate Smart Contracts node](https://github.com/paritytech/substrate-contracts-node) and
+configure the [Canvas UI](https://github.com/paritytech/canvas-ui) to interact with it.
 
 ## Running a Substrate Smart Contracts Node
 
@@ -248,8 +250,8 @@ substrate-contracts-node --dev --tmp
 
 You should start seeing blocks being produced by your node in your terminal.
 
-Go to the <ExternalLink url="https://paritytech.github.io/canvas-ui">hosted version of Canvas UI</ExternalLink>
-to interact with your node. You first need to configure the UI to connect to it:
+Go to the [hosted version of Canvas UI](https://paritytech.github.io/canvas-ui) to interact with
+your node. You first need to configure the UI to connect to it:
 
 - Click on the dropdown selector at bottom left corner.
 - Choose the Local Node.
@@ -448,4 +450,4 @@ get it functioning again, however this is beyond the scope of this tutorial.
 
 ### 5. Other Issues
 
-If you run into any other issues during this tutorial, please <ExternalLink url="https://github.com/substrate-developer-hub/substrate-contracts-workshop/issues">report an issue</ExternalLink> .
+If you run into any other issues during this tutorial, please [report an issue](https://github.com/substrate-developer-hub/substrate-contracts-workshop/issues)!

--- a/v3/tutorials/08-ink-workshop/b-develop-smart-contract/index.mdx
+++ b/v3/tutorials/08-ink-workshop/b-develop-smart-contract/index.mdx
@@ -67,7 +67,7 @@ Let's take a look at a high level what is available to you when developing a sma
 
 ### 1. ink!
 
-ink! is an <ExternalLink url="https://wiki.haskell.org/Embedded_domain_specific_language">Embedded Domain Specific Language</ExternalLink>
+ink! is an [Embedded Domain Specific Language](https://wiki.haskell.org/Embedded_domain_specific_language)
 (EDSL) that you can use to write WebAssembly based smart contracts in the Rust programming language.
 
 ink! is just standard Rust in a well defined "contract format" with specialized `#[ink(...)]` attribute macros. These attribute macros tell ink! what the different parts of your Rust smart contract represent, and ultimately allow ink! to do all the magic needed to create Substrate compatible Wasm bytecode!

--- a/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
+++ b/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
@@ -239,8 +239,8 @@ next slot ending period and be sure to re-register as needed.
  `}
 />
 
-- Go to [Polkadot-JS Apps UI](https://polkadot.js.org/apps/#/explorer), connecting to your
-  **relay chain**.
+- Go to [Polkadot Apps UI](https://polkadot.js.org/apps/),
+  connecting to your **relay chain**.
 
 - Execute a sudo extrinsic on the relay chain by going to `Developer` -> `sudo` page.
 
@@ -275,7 +275,7 @@ Here we will use `sudo` to grant ourselves a lease. You should have an onboarded
 
 ![parathread-onboarding.png](../../../../src/images/tutorials/09-cumulus/parathread-onboarding.png)
 
-- Go to <ExternalLink url="https://polkadot.js.org/apps/#/explorer">Polkadot Apps UI</ExternalLink>,
+- Go to [Polkadot Apps UI](https://polkadot.js.org/apps/),
   connecting to your **relay chain**.
 
 - Execute a sudo extrinsic on the relay chain by going to `Developer` -> `sudo` page.

--- a/v3/tutorials/09-cumulus/c-polkadot-launch/index.mdx
+++ b/v3/tutorials/09-cumulus/c-polkadot-launch/index.mdx
@@ -54,7 +54,7 @@ node dist/cli.js --version
 ```
 
 > If you think your edits are valuable, please
-> consider <ExternalLink url="https://github.com/paritytech/polkadot-launch">opening a PR</ExternalLink>!
+> consider [opening a PR](https://github.com/paritytech/polkadot-launch)!
 
 ## How `polkadot-launch` works
 
@@ -133,10 +133,8 @@ tail -f <logfile>
 ```
 
 Another way to verify the setup is by going to:
+[Polkadot-JS Apps > Network > Parachains](https://polkadot.js.org/apps/#/parachains).
 
-<ExternalLink url="https://polkadot.js.org/apps/#/parachains">
-  Polkadot-JS Apps > Network > Parachains
-</ExternalLink>
 
 After configure the Apps to connect to the local **relay chain node**, you should see the UI
 showing two parachains being connected to the relay chain.

--- a/v3/tutorials/09-cumulus/d-rococo/index.mdx
+++ b/v3/tutorials/09-cumulus/d-rococo/index.mdx
@@ -51,13 +51,8 @@ check what you need on a production network (maybe as a HTG)
 https://github.com/substrate-developer-hub/substrate-docs/issues/241
 -->
 
-<ExternalLink url="https://github.com/paritytech/polkadot/tree/release-v0.9.10">
-  Polkadot `release-v0.9.10` branch
-</ExternalLink>
-<p></p>
-<ExternalLink url="https://github.com/paritytech/cumulus/tree/polkadot-v0.9.10">
-  Cumulus `polkadot-v0.9.10` branch
-</ExternalLink>
+- [Polkadot `release-v0.9.10` branch](https://github.com/paritytech/polkadot/tree/release-v0.9.10)
+- [Cumulus `polkadot-v0.9.10` branch](https://github.com/paritytech/cumulus/tree/polkadot-v0.9.10)
 
 ### Request ROC Tokens
 
@@ -82,8 +77,10 @@ All parachains will need to register as a parathread first. You will need:
 - **5 ROCs** deposit to register a para ID.
 
 - [Reserve a unique para ID](connect-parachain#1-reserve-a-para-id). This will be assigned to the next
-  available ID. This integer will be greater than `2000`, as `0-999` are reserved for <ExternalLink url="https://wiki.polkadot.network/docs/learn-common-goods#system-level-chains">system parachains</ExternalLink> and
-  `1000-1999` are reserved for <ExternalLink url="https://wiki.polkadot.network/docs/learn-common-goods#public-utility-chains">public utility parachains</ExternalLink>.
+  available ID. This integer will be greater than `2000`, as `0-999` are reserved for
+  [system parachains](https://wiki.polkadot.network/docs/learn-common-goods#system-level-chains) and 
+  `1000-1999` are reserved for
+  [public utility parachains](https://wiki.polkadot.network/docs/learn-common-goods#public-utility-chains).
 
 - Your parachain genesis state. Refer to the
   [genesis state export process](connect-parachain#3-generate-parachain-genesis-state).
@@ -93,7 +90,8 @@ All parachains will need to register as a parathread first. You will need:
 
 The procedure will be as followed:
 
-- Goto Polkadot-JS Apps <ExternalLink url="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/parachains/parathreads">here</ExternalLink>
+- Goto Polkadot-JS Apps Rococo parathreads section
+  [here](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/parachains/parathreads).
 
 - Reserve for the next available para ID.
 
@@ -107,8 +105,9 @@ The procedure will be as followed:
 
   ![parathread-register-success.png](../../../../src/images/tutorials/09-cumulus/parathread-register-success.png)
 
-- Also in the Polkadot-JS Apps <ExternalLink url="https://polkadot.js.org/apps/#/parachains/parathreads">**Parachains > Parathreads** page</ExternalLink>
-  you will see your parathread registration is **Onboarding**:
+- Also in the Polkadot-JS Apps 
+  [Parachains -> Parathreads](https://polkadot.js.org/apps/#/parachains/parathreads)
+  page and you will see your parathread registration is **Onboarding**:
 
   ![parathread-onboarding.png](../../../../src/images/tutorials/09-cumulus/parathread-onboarding.png)
 
@@ -142,7 +141,9 @@ including on-boarding, off-boarding, upgrading, downgrading, etc.
 Anyone with a fully onboarded parathread can make a bid to win a parachain slot for their para ID.
 They need to out-bid all others participating in the slot auction.
 
-You can do so in Polkadot-JS App <ExternalLink url="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/parachains/auctions">**Network** > **Parachains** > **Auctions** page</ExternalLink>.
+You can do so in Polkadot-JS App
+[Network -> Parachains -> Auctions](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frococo-rpc.polkadot.io#/parachains/auctions)
+page.
 
 Pick your para ID, how much you want to bid, and the slots you want to bid for:
 
@@ -185,9 +186,8 @@ Notes on the parameters:
 
 If your extrinsic succeeds, you can see your new crowdloan entry in
 
-<ExternalLink url="https://polkadot.js.org/apps/#/parachains/crowdloan">
-  **Network** > **Parachains** > **Crowdloan** page
-</ExternalLink>
+[Network -> Parachains -> Crowdloan page](https://polkadot.js.org/apps/#/parachains/crowdloan)
+
 :
 
 ![crowdloan-success.png](../../../../src/images/tutorials/09-cumulus/crowdloan-success.png)
@@ -197,7 +197,8 @@ If your extrinsic succeeds, you can see your new crowdloan entry in
 Any accounts with a free balance and elect to contribute to your campaign, including the
 same account that started this campaign.
 
-You can goto the same <ExternalLink url="https://polkadot.js.org/apps/#/parachains/crowdloan">**Crowdloan** page</ExternalLink> above, and choose **+ Contribute** on the campaign you want to support.
+You can goto the same [Crowdloan page](https://polkadot.js.org/apps/#/parachains/crowdloan) above,
+and choose **+ Contribute** on the campaign you want to support.
 
 You will see an extrinsic pop up similar to the following:
 


### PR DESCRIPTION
This component is no longer useful, and should be removed based on #104 & #223
- [x]  All pages replaced with standard markdown link
- [ ] ~~remove the component itself (@imadarai )~~ we can't, it's used internally