### PR TITLE
Line Break between the code-block and component

### DIFF
--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -210,7 +210,7 @@ rustup update
 rustup update nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 ```
-
+<br/>
 <Message
   type={`gray`}
   title={`Note`}
@@ -252,7 +252,7 @@ project should use for Wasm compilation:
 ```bash
 WASM_BUILD_TOOLCHAIN=nightly-<yyyy-MM-dd> cargo build --release
 ```
-
+<br/>
 <Message
   type={`yellow`}
   title={`Information`}


### PR DESCRIPTION
Forcing a line-break between the code-block and the component, so it renders separately in production.  Addressing #356