### PR TITLE
Docker login fix

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,8 +12,8 @@ jobs:
   build-website-image:
     runs-on: ubuntu-latest
     steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      - name: Docker Login
+        uses: docker/login-action@v1.10.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fix the docker login issue, and link checking pass.

I'm also asking for a parity-owned docker repo to push the built image. But it would be on another PR.