### PR TITLE
Upgrade to `cargo-contract` `v0.15.0`

### DIFF
--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -108,7 +108,7 @@ brew install binaryen
 After you've installed the package execute:
 
 ```bash
-cargo install cargo-contract --vers ^0.14 --force --locked
+cargo install cargo-contract --vers ^0.15 --force --locked
 ```
 
 You can then use `cargo contract --help` to start exploring the commands made available to you.


### PR DESCRIPTION
We are using a fixed version of `cargo-contract` here to make sure that the workshop still works, despite whatever changes might be introduced in newer versions of `cargo-contract`.

We just issued a new release that doesn't break anything.