### PR TITLE
Rename "TwoX 128 hash" to  "TwoX 64 Concat hash"

### DIFF
--- a/v3/docs/07-advanced/g-storage/index.mdx
+++ b/v3/docs/07-advanced/g-storage/index.mdx
@@ -80,16 +80,17 @@ reading to learn how to calculate storage keys for the different types of storag
 ### Storage value keys
 
 To calculate the key for a simple [Storage Value](/v3/runtime/storage#storage-value), take the
-[TwoX 128 hash](https://github.com/Cyan4973/xxHash) of the name of the pallet that contains the
-Storage Value and append to it the TwoX 128 hash of the name of the Storage Value itself. For
-example, the [Sudo](/rustdocs/latest/pallet_sudo) pallet exposes a
+[TwoX 64 Concat hash](https://docs.substrate.io/v3/runtime/storage/#common-substrate-hashers)
+(a hash based on the concatenation of the [XXH64 hash](https://github.com/Cyan4973/xxHash))
+of the name of the pallet that contains the Storage Value and append to it the TwoX 64 Concat hash
+of the name of the Storage Value itself. For example, the [Sudo](/rustdocs/latest/pallet_sudo) pallet exposes a
 Storage Value item named
 [`Key`](/rustdocs/latest/pallet_sudo/struct.Module.html#method.key):
 
 ```
-twox_128("Sudo")                   = "0x5c0d1176a568c1f92944340dbfed9e9c"
-twox_128("Key")                    = "0x530ebca703c85910e7164cb7d1c9e47b"
-twox_128("Sudo") + twox_128("Key") = "0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b"
+twox_64_concat("Sudo")                         = "0x5c0d1176a568c1f92944340dbfed9e9c"
+twox_64_concat("Key")                          = "0x530ebca703c85910e7164cb7d1c9e47b"
+twox_64_concat("Sudo") + twox_64_concat("Key") = "0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b"
 ```
 
 If the familiar `Alice` account is the sudo user, an RPC request and response to read the Sudo
@@ -104,7 +105,7 @@ In this case, the value that is returned
 [SCALE](../scale-codec)-encoded account ID (`5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY`).
 
 You may have noticed that the
-[non-cryptographic](/v3/runtime/storage#cryptographic-hashing-algorithms) TwoX 128 hash algorithm is
+[non-cryptographic](/v3/runtime/storage#cryptographic-hashing-algorithms) TwoX 64 Concat hash algorithm is
 used to generate Storage Value keys. This is because it is not necessary to pay the performance
 costs associated with a cryptographic hash function since the input to the hash function (the names
 of the pallet and storage item) are determined by the runtime developer and not by potentially
@@ -113,11 +114,11 @@ malicious users of your blockchain.
 ### Storage map keys
 
 Like Storage Values, the keys for [Storage Maps](/v3/runtime/storage#storage-map) are equal to the
-TwoX 128 hash of the name of the pallet that contains the map prepended to the TwoX 128 hash of the
+TwoX 64 Concat hash of the name of the pallet that contains the map prepended to the TwoX 64 Concat hash of the
 name of the Storage Map itself. To retrieve an element from a map, simply append the hash of the
 desired map key to the storage key of the Storage Map. For maps with two keys (Storage Double Maps),
 append the hash of the first map key followed by the hash of the second map key to the Storage
-Double Map's storage key. Like Storage Values, Substrate will use the TwoX 128 hashing algorithm for
+Double Map's storage key. Like Storage Values, Substrate will use the TwoX 64 Concat hashing algorithm for
 the pallet and Storage Map names, but you will need to make sure to use the correct
 [hashing algorithm](/v3/runtime/storage#hashing-algorithms) (the one that was declared in
 [the `#[pallet::storage]` macro](/v3/runtime/storage#declaring-storage-items)) when determining the hashed
@@ -129,8 +130,8 @@ is using
 [the transparent Blake2 128 Concat hashing algorithm](/v3/runtime/storage#transparent-hashing-algorithms):
 
 ```
-twox_128("Balances")                                             = "0xc2261276cc9d1f8598ea4b6a74b15c2f"
-twox_128("FreeBalance")                                          = "0x6482b9ade7bc6657aaca787ba1add3b4"
+twox_64_concat("Balances")                                       = "0xc2261276cc9d1f8598ea4b6a74b15c2f"
+twox_64_concat("FreeBalance")                                    = "0x6482b9ade7bc6657aaca787ba1add3b4"
 scale_encode("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY") = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
 
 blake2_128_concat("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d") = "0xde1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
@@ -155,8 +156,8 @@ in a pallet named "Balances") that will demonstrate using the Substrate RPC to q
 for its list of keys via the `state_getKeys` RPC endpoint:
 
 ```
-twox_128("Balances")                                      = "0xc2261276cc9d1f8598ea4b6a74b15c2f"
-twox_128("FreeBalance")                                   = "0x6482b9ade7bc6657aaca787ba1add3b4"
+twox_64_concat("Balances")                                      = "0xc2261276cc9d1f8598ea4b6a74b15c2f"
+twox_64_concat("FreeBalance")                                   = "0x6482b9ade7bc6657aaca787ba1add3b4"
 
 state_getKeys("0xc2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4") = [
 	"0xc2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
@@ -172,7 +173,7 @@ example (the one used to find the balance for `Alice`). Because the map that the
 uses a transparent hashing algorithm to generate its keys, it is possible to determine the account
 associated with the second element in the list. Notice that each element in the list is a
 hexadecimal value that begins with the same 64 characters; this is because each list element
-represents a key in the same map, and that map is identified by concatenating two TwoX 128 hashes,
+represents a key in the same map, and that map is identified by concatenating two TwoX 64 Concat hashes,
 each of which are 128-bits or 32 hexadecimal characters. After discarding this portion of the second
 element in the list, you are left with
 `0x32a5935f6edc617ae178fef9eb1e211fbe5ddb1579b72e84524fc29e78609e3caf42e85aa118ebfe0b0ad404b5bdd25f`.


### PR DESCRIPTION
I spent a long time trying to figure out what was I doing wrong, because my hashes didn't match with the hashes of the docs.

It turns out that when the docs were written [the XXH128 hash](https://github.com/Cyan4973/xxHash) didn't exist yet, and that's probably why back then we used to refer to the ["TwoX 64 Concat" hash](https://docs.substrate.io/v3/runtime/storage/#common-substrate-hashers) as "TwoX 128" hash. However, now that the 128 version of the TwoX hash exists, we should make sure that we always use the term "TwoX 64 Concat", otherwise it can be confusing.