### PR TITLE
Remove instances of Substrate Wiki

### DIFF
--- a/v3/docs/06-tools/a-subkey/index.mdx
+++ b/v3/docs/06-tools/a-subkey/index.mdx
@@ -20,7 +20,7 @@ Its main feature is generating and inspecting key pairs, currently supporting th
 All keys in Substrate based networks
 ([like polkadot](https://wiki.polkadot.network/docs/learn-accounts#address-format))
 use the
-[SS58 address encoding format](<https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58)>)
+[SS58 address encoding format](/v3/advanced/ss58/)
 that is the primary user-facing way to interact with keys.
 
 Subkey also allows restoring keys from mnemonics and raw seeds; signing and verifying signatures

--- a/v3/docs/07-advanced/h-ss58/index.mdx
+++ b/v3/docs/07-advanced/h-ss58/index.mdx
@@ -15,9 +15,6 @@ The basic idea is a base-58 encoded value that can identify a specific account o
 chain. Different chains have different means of identifying accounts. SS58 is designed to be
 extensible for this reason.
 
-The living specification for the SS58 address format can be found on the
-[Substrate GitHub wiki](<https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58)>).
-
 ## Validating addresses
 
 There are several ways to verify that a value is a valid SS58 address.


### PR DESCRIPTION
Based on [this](https://github.com/paritytech/substrate/issues/10052), I've removed references to the now archived Substrate Wiki. 