### PR TITLE
Fix Ubuntu installation instructions

### DIFF
--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -27,7 +27,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev g++
 ```
 
 ### Arch Linux

--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -27,7 +27,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev g++
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev g++ zlib1g-dev
 ```
 
 ### Arch Linux

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -111,7 +111,7 @@ To install required packages on macOS or Linux:
 
   | OS | Installation commands
   | ------------------------- | --------------------------
-  | Ubuntu or Debian | `sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev`
+  | Ubuntu or Debian | `sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev g++`
   | Arch Linux | `pacman -Syu --needed --noconfirm curl git clang`
   | Fedora | `sudo dnf update sudo dnf install clang curl git openssl-devel`
   | OpenSUSE | `sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel`

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -111,7 +111,7 @@ To install required packages on macOS or Linux:
 
   | OS | Installation commands
   | ------------------------- | --------------------------
-  | Ubuntu or Debian | `sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev g++`
+  | Ubuntu or Debian | `sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev g++ zlib1g-dev`
   | Arch Linux | `pacman -Syu --needed --noconfirm curl git clang`
   | Fedora | `sudo dnf update sudo dnf install clang curl git openssl-devel`
   | OpenSUSE | `sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel`


### PR DESCRIPTION
* Add `g++` package to Ubuntu installation instructions. Otherwise, cargo-build on package `librocksdb-sys` fails with `error occurred: Failed to find tool. Is c++ installed?`
* Add `zlib1g-dev` package to Ubuntu installation instructions. Otherwise, cargo-build fails on linking with 
```
  = note: /usr/bin/ld: cannot find -lz           
          collect2: error: ld returned 1 exit status
```