### PR TITLE
Remove canvas-ui warning

### DIFF
--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -254,13 +254,6 @@ You should start seeing blocks being produced by your node in your terminal.
 
 ## Deploying your Contract
 
-<Message
-  type={`red`}
-  title={`Important`}
-  text={`Canvas UI is undergoing technical difficulties and is not functional at the moment. While we are working on a fix, 
-  please use https://polkadot.js.org/apps/ to deploy and interact with your contracts. Same principles apply, the UI differs slightly. 
-  Make sure you are connected to the local node by selecting it from the top left menu and that you navigate to Developer/Contracts page`}
-/>
 
 Go to the [hosted version of Canvas UI](https://paritytech.github.io/canvas-ui) to interact with
 your node. You first need to configure the UI to connect to it:
@@ -338,14 +331,6 @@ creation of a new account (`system.NewAccount`) and the instantiation of the con
 
 ## Calling your Contract
 
-<Message
-  type={`red`}
-  title={`Important`}
-  text={`Canvas UI is undergoing technical difficulties and is not functional at the moment. While we are working on a fix, 
-  please use https://polkadot.js.org/apps/ to deploy and interact with your contracts. Same principles apply, the UI differs slightly. 
-  Make sure you are connected to the local node by selecting it from the top left menu and that you navigate to Developer/Contracts page`}
-/>
-
 Now that your contract has been fully deployed, we can start interacting with it! Flipper only has
 two functions, `flip()` and `get()` so we will show you what it's like to play with both of them.
 Click the **Execute** button under the contract after you instantiate the Flipper contract in the
@@ -409,14 +394,6 @@ You need not deploy your contract between each section, but if we ask you to dep
 you will need to follow these same steps you have done with the Flipper contract.
 
 ## Troubleshooting
-
-<Message
-  type={`red`}
-  title={`Important`}
-  text={`Canvas UI is undergoing technical difficulties and is not functional at the moment. While we are working on a fix, 
-  please use https://polkadot.js.org/apps/ to deploy and interact with your contracts. Same principles apply, the UI differs slightly. 
-  Make sure you are connected to the local node by selecting it from the top left menu and that you navigate to Developer/Contracts page`}
-/>
 
 Here are solutions to some of the common problems you may come across:
 


### PR DESCRIPTION
Remove the warning that was introduced [here](https://github.com/substrate-developer-hub/substrate-docs/pull/421), now that the metadata update issue was resolved