### PR TITLE
typo

### DIFF
--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -174,7 +174,7 @@ To define the `Config` trait for the proof-of-existence pallet:
 
 ## Implement pallet events
 
-Now that you've configured the pallet to emit events, you are redy to define those events.
+Now that you've configured the pallet to emit events, you are ready to define those events.
 As described in [Design the application](#design-the-application), the proof-of-existence pallet emits an event under the following conditions:
 
 * When a new proof is added to the blockchain.


### PR DESCRIPTION
typo: `redy` should be `ready`