### PR TITLE
Changed the dependency pallet-scheduler.

### DIFF
--- a/v3/tutorials/04-forkless-upgrades/index.mdx
+++ b/v3/tutorials/04-forkless-upgrades/index.mdx
@@ -226,7 +226,11 @@ First, add the Scheduler pallet as a dependency in the template node's runtime C
 **`runtime/Cargo.toml`**
 
 ```toml
-pallet-scheduler = { default-features = false, version = '3.0.0' }
+   [dependencies.pallet-scheduler]
+   default-features = false
+   git = 'https://github.com/paritytech/substrate.git'
+   tag = 'monthly-2021-10'
+   version = '4.0.0-dev'
 
 #--snip--
 


### PR DESCRIPTION
I have changed the pallet-scheduler dependency from,

pallet-scheduler = { default-features = false, version = '3.0.0' }  // which was not working

to

        [dependencies.pallet-scheduler]
        default-features = false
        git = 'https://github.com/paritytech/substrate.git'
        tag = 'monthly-2021-10'    // latest tag here.
        version = '4.0.0-dev'

For me node-template was not compiling the project with the dependency defined in the docs, so I changed it and it's working fine now.