### PR TITLE
typo

### DIFF
--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -87,7 +87,7 @@ A node associated with a `PeerId` must have **one and only one owner**.
 The owner of a well known node is specified when adding it.
 If it's a normal node, _any_ user can claim a `PeerId` as its owner.
 To protect against false claims, the maintainer of the node should claim it
-_before even starting the node_ and therefor revealing their `PeerID` to the network that
+_before even starting the node_ and therefore revealing their `PeerID` to the network that
 _anyone_ could subsequently claim.
 
 The owner of a node can then add and remove connections for their node.


### PR DESCRIPTION
typo: `therefor` should be `therefore`