### PR TITLE
Missed line

### DIFF
--- a/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
+++ b/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
@@ -12,6 +12,7 @@ pub mod pallet {
 		transactional
 	};
 	use sp_io::hashing::blake2_128;
+	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};

--- a/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
+++ b/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
@@ -12,6 +12,7 @@ pub mod pallet {
 		transactional
 	};
 	use sp_io::hashing::blake2_128;
+	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};

--- a/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
+++ b/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
@@ -15,6 +15,7 @@ pub mod pallet {
     transactional
   };
   use sp_io::hashing::blake2_128;
+  use scale_info::TypeInfo;
 
   #[cfg(feature = "std")]
   use serde::{Deserialize, Serialize};

--- a/static/assets/tutorials/kitties-tutorial/05-completed.rs
+++ b/static/assets/tutorials/kitties-tutorial/05-completed.rs
@@ -15,6 +15,7 @@ pub mod pallet {
 		transactional
 	};
 	use sp_io::hashing::blake2_128;
+	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]
 	use serde::{Deserialize, Serialize};


### PR DESCRIPTION
It seems like the following line is missed in examples files
```use scale_info::TypeInfo;```
it produces compilation errors.