### PR TITLE
Fix SCALE compact example

### DIFF
--- a/v3/docs/07-advanced/b-scale-codec/index.mdx
+++ b/v3/docs/07-advanced/b-scale-codec/index.mdx
@@ -70,7 +70,7 @@ It is encoded with the two least significant bits denoting the mode:
 - `unsigned integer 1`: `0x04`
 - `unsigned integer 42`: `0xa8`
 - `unsigned integer 69`: `0x1501`
-- `unsigned integer 65535`: `0xf3ff0300`
+- `unsigned integer 65535`: `0xfeff0300`
 - `BigInt(100000000000000)`: `0x0b00407a10f35a`
 
 Error:


### PR DESCRIPTION
Found a discrepancy while using `cScale` library, confirmed with `parity-scale-codec`:

```
let test_compact_32: u32 = 65535;
println!("Compact {} encoded = {:02X?}", test_compact_32, Compact(test_compact_32).encode());
```
```
Compact 65535 encoded = [FE, FF, 03, 00]
```

Polkadot address: 12uzeddBwDaBEb9Gny6Q6ySeAtfUuA4kucacrACgMT6YVNRA