### PR TITLE
Update setup guide for Apple M1

### DIFF
--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -60,7 +60,7 @@ sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel
 <Message
   type={`yellow`}
   title={`Information`}
-  text="If you have an Apple M1 ARM system on a chip, make sure that you have Apple Rosetta 2 installed through `softwareupdate --install-rosetta`. This is only needed to run the protoc tool during the build. The build itself and the target binaries would remain native."
+  text="If you have an Apple M1 ARM system on a chip, make sure that you have Apple Rosetta 2 installed through \`softwareupdate --install-rosetta\`. This is only needed to run the \`protoc\` tool during the build. The build itself and the target binaries would remain native."
 />
 
 Open the Terminal application and execute the following commands:

--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -59,7 +59,7 @@ sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel
 
 <Message
   type={`yellow`}
-  title={`Information`}
+  title={`Apple M1 ARM`}
   text="If you have an Apple M1 ARM system on a chip, make sure that you have Apple Rosetta 2 installed through \`softwareupdate --install-rosetta\`. This is only needed to run the \`protoc\` tool during the build. The build itself and the target binaries would remain native."
 />
 

--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -60,13 +60,7 @@ sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel
 <Message
   type={`yellow`}
   title={`Information`}
-  text="The Apple M1 ARM system on a chip is not very well supported yet by rust, and thus you very likely will run into build errors stemming from this. There are reports that using substrate dependencies newer than the June 2021 monthly release are able to work without issue. Here is the ',
-    [node template `monthly-2021-05`](https://github.com/substrate-developer-hub/substrate-node-template/tree/v3.0.0%2Bmonthly-2021-05)
-    'that you should use as a base for building on M1s. If you decide not to use a monthly release, see 
-    [this community contributed script](https://github.com/substrate-developer-hub/substrate-node-template/issues/179#issuecomment-843522331)
-    (and discussion)
-    for details on extra configuration steps to get things working on `v3.0.0` and below.
-    "
+  text="If you have an Apple M1 ARM system on a chip, make sure that you have Apple Rosetta 2 installed through `softwareupdate --install-rosetta`. This is only needed to run the protoc tool during the build. The build itself and the target binaries would remain native."
 />
 
 Open the Terminal application and execute the following commands:


### PR DESCRIPTION
Remove the previous outdated advice and add  rosetta 2 requirement. See the discussion here: https://github.com/paritytech/substrate/issues/10203