### PR TITLE
Kitty tutorial updates: new pallet declaration, removing types.json and updating write-up

### DIFF
--- a/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
+++ b/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
@@ -15,7 +15,7 @@ pub mod pallet {
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]
-	use serde::{Deserialize, Serialize};
+	use frame_support::serde::{Deserialize, Serialize};
 
 	// ACTION #1: Write a Struct to hold Kitty information.
 

--- a/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
+++ b/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
@@ -15,7 +15,7 @@ pub mod pallet {
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]
-	use serde::{Deserialize, Serialize};
+	use frame_support::serde::{Deserialize, Serialize};
 
 	type AccountOf<T> = <T as frame_system::Config>::AccountId;
 	type BalanceOf<T> =

--- a/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
+++ b/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
@@ -18,7 +18,7 @@ pub mod pallet {
   use scale_info::TypeInfo;
 
   #[cfg(feature = "std")]
-  use serde::{Deserialize, Serialize};
+  use frame_support::serde::{Deserialize, Serialize};
 
   type AccountOf<T> = <T as frame_system::Config>::AccountId;
   type BalanceOf<T> =

--- a/static/assets/tutorials/kitties-tutorial/05-completed.rs
+++ b/static/assets/tutorials/kitties-tutorial/05-completed.rs
@@ -18,7 +18,7 @@ pub mod pallet {
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]
-	use serde::{Deserialize, Serialize};
+	use frame_support::serde::{Deserialize, Serialize};
 
 	type AccountOf<T> = <T as frame_system::Config>::AccountId;
 	type BalanceOf<T> =

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -49,7 +49,7 @@ For the purposes of what we're building, Kitties really can only do the followin
 The following items fall outside the scope of this tutorial:
 
 - Writing tests for our pallet.
-- Using correct weight values
+- Using correct weight values.
 
 You can refer to the [how-to guides](/how-to-guides/v3) on how to integrate these once you've completed this workshop.
 
@@ -57,7 +57,7 @@ Follow each step at your own pace &mdash; the goal is for you to learn and the b
 Before moving on from one section to the next, make sure your pallet builds without any error.
 Use the [template files](https://github.com/substrate-developer-hub/substrate-docs/tree/main/static/assets/tutorials/kitties-tutorial) to help you complete each part.
 If you are stuck you can refer to the complete source code on the [Substrate Node Template repository \`tutorials/kitties\` branch](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/kitties).
-Most of the code changes are under \`/pallets/kitties/src/lib.rs\`.
+Most of the code changes will be in `/pallets/kitties/src/lib.rs`.
 
 ## Basic set-up
 
@@ -66,58 +66,52 @@ This part covers the basic patterns involved with using the Substrate Node Templ
 
 ### Set-up your template node
 
-The [Substrate Node Template][substrate-node-template] provides us with an "out-of-the-box" blockchain node.
-Our biggest advantage in using it are that both networking and consensus layers are already built.
+The [Substrate Node Template][substrate-node-template] provides us with an customizable blockchain node, with built-in networking and consensus layers included.
 All we need to focus on is building out the logic of our [runtime][runtime-kb] and [pallets][pallets-kb].
-Before we get there, we need to set-up our project in terms of naming and dependencies.
 
+To kick things off, we need to set-up our project name and dependencies.
 We'll use a CLI tool called [kickstart][kickstart-tool] to easily rename our node template.
-Install it by running `cargo install kickstart`.
+1. Install it by running `cargo install kickstart`.
 
-Once `kickstart` is installed, in the root directory of your local workspace run the following command:
+1. Once `kickstart` is installed, in the root directory of your local workspace run the following command:
 
-```bash
-kickstart https://github.com/sacha-l/kickstart-substrate
-```
+  ```bash
+  kickstart https://github.com/sacha-l/kickstart-substrate
+  ```
 
-This command will clone a copy of the most recent Node Template and ask how you would like to call your node and pallet.
+  This command will clone a copy of the most recent Node Template and ask how you would like to call your node and pallet.
 
-Type in:
+1. Type in:
 
-- `kitties` - as the name of our node. The node will be named as `node-kitties`.
-- `kitties` - as the name of your pallet. The pallet will be named as `pallet-kitties`.
+    - `kitties` - as the name of our node. The node will be named as `node-kitties`.
+    - `kitties` - as the name of your pallet. The pallet will be named as `pallet-kitties`.
 
-This will create a directory called `kitties` with a copy of the [Substrate Node Template][substrate-node-template] containing the name changes that correspond our template node, runtime, and pallet.
+  This will create a directory called `kitties` with a copy of the [Substrate Node Template][substrate-node-template] containing the name changes that correspond our template node, runtime, and pallet.
 
-Open the `kitties` directory in your favorite code editor and rename it as `kitties-tutorial`.
-Renaming this directory will be helpful once you start creating other projects with the node template &mdash; it'll help keep things organized!
+1. Open the `kitties` directory in your favorite code editor and rename it as `kitties-tutorial` &mdash; or whatever name you like to help keep your work organized.
 
-Notice the directories that the `kickstart` command modified:
+    Notice the directories that the `kickstart` command modified:
 
-- **\`/node/\`** - This contains all the logic that allows your node to interact with your runtime and RPC clients.
-- **\`/pallets/\`** - Here's where all your custom pallets live.
-- **\`/runtime/\`** - This is where all pallets (both custom "internal" and "external" ones) are aggregated and implemented for the chain's runtime.
+    - **/node/** - This folder contains all the logic that allows your node to interact with your runtime and RPC clients.
+    - **/pallets/** - Here's where all your custom pallets live.
+    - **/runtime/** - This folder is where all pallets (both custom "internal" and "external" ones) are aggregated and implemented for the chain's runtime.
 
-You'll also notice that the instance of our modified template pallet name remains `TemplateModule`.
-Change it to `SubstrateKitties` (in `runtime/src/lib.rs`) and add `Config<T>` to the pallet declaration:
+1. In `runtime/src/lib.rs`, you'll also notice that the instance of our modified template pallet name remains `TemplateModule`.
+Change it to `SubstrateKitties`:
 
-```rust
-construct_runtime!(
-    pub enum Runtime where
-    Block = Block,
-    NodeBlock = opaque::Block,
-    UncheckedExtrinsic = UncheckedExtrinsic
-    {
-        // --snip
-        SubstrateKitties: pallet_kitties::{Pallet, Call, Config<T>, Storage, Event<T>}, // <-- add this line
-    }
-);
-```
+  ```rust
+  construct_runtime!(
+      // --snip
+      {
+          // --snip
+          SubstrateKitties: pallet_kitties,
+      }
+  );
+  ```
 
 ### Write the `pallet_kitties` scaffold
 
-We'll be spending most of this tutorial in the `pallets` directory of our template node.
-Let's take a glance at the folder structure in our workspace:
+Let's take a glance at the folder structure of our workspace:
 
 ```bash
 kitties-tutorial           <--  The name of our project directory
@@ -150,10 +144,10 @@ kitties-tutorial           <--  The name of our project directory
 [Pallets][pallets-kb] in Substrate are used to define runtime logic.
 In our case, we'll be creating a single pallet that manages all of the logic of our Substrate Kitties application.
 
-Let's lay out the basic structure of our pallet by outlining the parts inside `pallets/kitties/src/lib.rs`.
-
-Notice that our pallet's directory `pallets/kitties/` is not the same as our pallet's name.
+Notice that our pallet's directory `/pallets/kitties/` is not the same as our pallet's name.
 The name of our pallet as Cargo understands it is `pallet-kitties`.
+
+Let's lay out the basic structure of our pallet by outlining the parts inside `pallets/kitties/src/lib.rs`.
 
 Every FRAME pallet has:
 
@@ -172,104 +166,104 @@ Here's the most bare-bones version of the Kitties pallet we will be building in 
 It contains the starting point for adding code for the next sections of this tutorial.
 Just like the [helper files](https://github.com/substrate-developer-hub/substrate-docs/tree/main/static/assets/tutorials/kitties-tutorial) for this tutorial, it contains comments marked with **TODO** to indicate code we will be writing later, and **ACTION** to indicate code that will be written in the current section.
 
-Paste the following code in `/pallets/kitties/src/lib.rs`:
+1. Paste the following code in `/pallets/kitties/src/lib.rs`:
 
-```rust
-#![cfg_attr(not(feature = "std"), no_std)]
+  ```rust
+  #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use pallet::*;
+  pub use pallet::*;
 
-#[frame_support::pallet]
-pub mod pallet {
-    use frame_support::{sp_runtime::traits::{Hash, Zero},
-                        dispatch::{DispatchResultWithPostInfo, DispatchResult},
-                        traits::{Currency, ExistenceRequirement, Randomness},
-                        pallet_prelude::*};
-    use frame_system::pallet_prelude::*;
-    use sp_io::hashing::blake2_128;
+  #[frame_support::pallet]
+  pub mod pallet {
+      use frame_support::{sp_runtime::traits::{Hash, Zero},
+                          dispatch::{DispatchResultWithPostInfo, DispatchResult},
+                          traits::{Currency, ExistenceRequirement, Randomness},
+                          pallet_prelude::*};
+      use frame_system::pallet_prelude::*;
+      use sp_io::hashing::blake2_128;
 
-    // TODO Part II: Struct for holding Kitty information.
+      // TODO Part II: Struct for holding Kitty information.
 
-    // TODO Part II: Enum and implementation to handle Gender type in Kitty struct.
+      // TODO Part II: Enum and implementation to handle Gender type in Kitty struct.
 
-    #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
-    #[pallet::generate_storage_info]
-    pub struct Pallet<T>(_);
+      #[pallet::pallet]
+      #[pallet::generate_store(pub(super) trait Store)]
+      #[pallet::generate_storage_info]
+      pub struct Pallet<T>(_);
 
-    /// Configure the pallet by specifying the parameters and types it depends on.
-    #[pallet::config]
-    pub trait Config: frame_system::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+      /// Configure the pallet by specifying the parameters and types it depends on.
+      #[pallet::config]
+      pub trait Config: frame_system::Config {
+          /// Because this pallet emits events, it depends on the runtime's definition of an event.
+          type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
-        /// The Currency handler for the Kitties pallet.
-        type Currency: Currency<Self::AccountId>;
+          /// The Currency handler for the Kitties pallet.
+          type Currency: Currency<Self::AccountId>;
 
-        // TODO Part II: Specify the custom types for our runtime.
+          // TODO Part II: Specify the custom types for our runtime.
 
-    }
+      }
 
-    // Errors.
-    #[pallet::error]
-    pub enum Error<T> {
-        // TODO Part III
-    }
+      // Errors.
+      #[pallet::error]
+      pub enum Error<T> {
+          // TODO Part III
+      }
 
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config> {
-        // TODO Part III
-    }
+      #[pallet::event]
+      #[pallet::generate_deposit(pub(super) fn deposit_event)]
+      pub enum Event<T: Config> {
+          // TODO Part III
+      }
 
-    // ACTION: Storage item to keep a count of all existing Kitties.
+      // ACTION: Storage item to keep a count of all existing Kitties.
 
-    // TODO Part II: Remaining storage items.
+      // TODO Part II: Remaining storage items.
 
-    // TODO Part III: Our pallet's genesis configuration.
+      // TODO Part III: Our pallet's genesis configuration.
 
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {
+      #[pallet::call]
+      impl<T: Config> Pallet<T> {
 
-        // TODO Part III: create_kitty
+          // TODO Part III: create_kitty
 
-        // TODO Part III: set_price
+          // TODO Part III: set_price
 
-        // TODO Part III: transfer
+          // TODO Part III: transfer
 
-        // TODO Part III: buy_kitty
+          // TODO Part III: buy_kitty
 
-        // TODO Part III: breed_kitty
-    }
+          // TODO Part III: breed_kitty
+      }
 
-    // TODO Parts II: helper function for Kitty struct
+      // TODO Parts II: helper function for Kitty struct
 
-    impl<T: Config> Pallet<T> {
-        // TODO Part III: helper functions for dispatchable functions
+      impl<T: Config> Pallet<T> {
+          // TODO Part III: helper functions for dispatchable functions
 
-        // TODO: increment_nonce, random_hash, mint, transfer_from
+          // TODO: increment_nonce, random_hash, mint, transfer_from
 
-    }
-}
-```
+      }
+  }
+  ```
 
-Notice that we're using `sp_io` in our pallet.
+1. Notice that we're using `sp_io` in our pallet.
 Ensure that this is declared as a dependency in your pallet's `Cargo.toml` file:
 
-```toml
-[dependencies.sp-io]
-default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-10'
-version = '4.0.0-dev'
-```
+  ```toml
+  [dependencies.sp-io]
+  default-features = false
+  git = 'https://github.com/paritytech/substrate.git'
+  tag = 'monthly-2021-11'
+  version = '4.0.0-dev'
+  ```
 
-Now try running the following command to build your pallet. We won't build the entire chain just yet because we haven't yet implemented the `Currency` type in our runtime.
+1. Now try running the following command to build your pallet. We won't build the entire chain just yet because we haven't yet implemented the `Currency` type in our runtime.
 At least we can check that there are no errors in our pallet so far:
 
-```bash
-cargo build -p pallet-kitties
-```
+  ```bash
+  cargo build -p pallet-kitties
+  ```
 
 <br />
 <Message
@@ -277,17 +271,17 @@ cargo build -p pallet-kitties
   title={`Warning`}
   text={`
 Check that you're using the correct \`monthly-*\` tag and version otherwise you will get a
-dependency error. Here, we're using the \`monthly-2021-10\` tag of Substrate.
+dependency error. Here, we're using the \`monthly-2021-11\` tag of Substrate.
   `}
 />
 
 You'll notice the Rust compiler giving you warnings about unused imports.
-That's fine! Just ignore them &mdash; we're going to be using those imports in the later parts of the tutorial.
+That's fine! 
+Just ignore them &mdash; we're going to be using those imports in the later parts of the tutorial.
 
 ### Add storage items
 
-Let's start add the most simple logic we can to our runtime: a function that stores a variable in runtime.
-
+Let's add the most simple logic we can to our runtime: a function that stores a variable in our runtime.
 To do this we'll use [`StorageValue`][storagevalue-rustdocs] from Substrate's [storage API][storage-api-rustdocs] which is a trait that depends on the [storage macro][storage-macro-kb].
 
 All that means for our purposes is that for any storage item we want to declare, we must include the `#[pallet::storage]` macro beforehand.
@@ -336,21 +330,12 @@ various patterns for:
 
 ## Uniqueness, custom types and storage maps
 
-This section dives into some pillar concepts for developing pallets with FRAME (**Framework for Runtime Aggregation of Modularized Entities**), incuding writing [a storage struct](/how-to-guides/v3/pallet-design/storage-value) and [implementing the randomness trait](/how-to-guides/v3/pallet-design/randomness).
-On top of learning how to use existing types and traits, you'll learn how create your own types like providing your pallet with a `Gender` type.
-At the end of this part, you will have implemented the remaining two storage items according to the logic outlined for the Substrate Kitty application [in the overview of this tutorial](#what-were-building).
+You're ready to dive into some pillar concepts for developing pallets with FRAME (**Framework for Runtime Aggregation of Modularized Entities**), incuding writing [a storage struct](/how-to-guides/v3/pallet-design/storage-value) and [implementing the randomness trait](/how-to-guides/v3/pallet-design/randomness).
 
-We added additional comments to the code from Part I in a dedicated helper file to better assist you with the action items of this section.
-To follow each step with ease, you can just replace your code with the [helper code](https://github.com/substrate-developer-hub/substrate-docs/tree/main/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs) provided below:
+Use the [helper code](https://github.com/substrate-developer-hub/substrate-docs/tree/main/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs) provided below to help you complete each step. 
+This will be the basis of the next few steps.
 
-<Message
-  type={`green`}
-  title={`Tip`}
-  text={`
-If you're feeling confident, you can use the code from the previous part and use the comments marked
-as "TODO" to follow each step instead of pasting in the helper file for this part.
-  `}
-/>
+Update your pallet code with the following code snip (skip this step if you prefer not to use the template code):
 
 ```rust
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -515,7 +500,6 @@ use scale_info::TypeInfo;
 ```
 
 For type `Gender`, we will need to build out our own custom enum and helper functions.
-Now is a good time to do that.
 
 ### Write a custom type for `Gender`
 
@@ -526,55 +510,49 @@ To create it, you'll build out the following parts:
 - **An enum declaration**, which specifies `Male` and `Female` values.
 - **Implement a helper function** for our Kitty struct.
 
-1. #### Declare the custom enum
+1. Replace ACTION item #2 with the following enum declaration:
 
-Replace ACTION item #2 with the following enum declaration:
+  ```rust
+    #[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
+    #[scale_info(skip_type_params(T))]
+  #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+  pub enum Gender {
+      Male,
+      Female,
+  }
+  ```
 
-```rust
-	#[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
-	#[scale_info(skip_type_params(T))]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum Gender {
-    Male,
-    Female,
-}
-```
+  Notice the use of the [derive macro][derive-macro-rust] which must precede the enum declaration.
+  This wraps our enum in the data structures it will need to interface with other types in our runtime.
 
-Notice the use of the [derive macro][derive-macro-rust] which must precede the enum declaration.
-This wraps our enum in the data structures it will need to interface with other types in our runtime.
-In order to use `Serialize` and `Deserialize`, you will need to add the `serde` crate in `pallets/kitties/Cargo.toml`:
+1. In order to use `Serialize` and `Deserialize`, you will need to add the `serde` crate in `pallets/kitties/Cargo.toml`:
 
-```toml
-[dependencies.serde]
-default-features = false
-version = '1.0.119'
-```
+  ```toml
+  [dependencies.serde]
+  default-features = false
+  version = '1.0.119'
+  ```
 
-Great, we now know how to create a custom struct.
-But what about providing a way for a Kitty struct to be _assigned_ a gender value?
-For that we need to learn one more thing.
+  Great, we now know how to create a custom struct.
+  But what about providing a way for a Kitty struct to be _assigned_ a gender value?
+  For that we need to configure it using a helper function.
 
-1. #### Implement a helper function for our Kitty struct
+  Configuring a struct is useful in order to pre-define a value in our struct.
+  For example, when setting a value in relation to what another function returns.
+  In our case we have a similar situation where we need to configure our Kitty struct in such a way that sets `Gender` according to a Kitty's DNA.
+  To do this, we'll create a public function called `gen_gender` that returns the `Gender` type and uses a random function to choose between `Gender` enum values.
 
-Configuring a struct is useful in order to pre-define a value in our struct.
-For example, when setting a value in relation to what another function returns.
-In our case we have a similar situation where we need to configure our Kitty struct in such a way that sets `Gender` according to a Kitty's DNA.
+1. Replace ACTION #4 with the following code snippet:
 
-We'll only be using this function when we get to [creating Kitties](#write-the-create_kitty-dispatchable).
-Regardless, let us learn how to write it now and get it out of the way.
-We'll create a public function called `gen_gender` that returns the `Gender` type and uses a random function to choose between `Gender` enum values.
-
-Replace ACTION #4 with the following code snippet:
-
-```rust
-fn gen_gender() -> Gender {
-    let random = T::KittyRandomness::random(&b"gender"[..]).0;
-    match random.as_ref()[0] % 2 {
-        0 => Gender::Male,
-        _ => Gender::Female,
-    }
-}
-```
+  ```rust
+  fn gen_gender() -> Gender {
+      let random = T::KittyRandomness::random(&b"gender"[..]).0;
+      match random.as_ref()[0] % 2 {
+          0 => Gender::Male,
+          _ => Gender::Female,
+      }
+  }
+  ```
 
 Now whenever `gen_gender()` is called inside our pallet, it will return a pseudo random enum value for `Gender`.
 
@@ -587,59 +565,56 @@ Let's get to it.
 We'll be using the [Randomness trait][randomness-rustdocs] from `frame_support` to do this.
 It will be able to generate a random seed which we'll create unique Kitties with as well as breed new ones.
 
-In order to use the `Randomness` trait for our pallet, we must:
+1. In your pallet's configuration traite, define a new type bound by the `Randomness` trait.
 
-1. #### Define a new type bound by `Randomness` trait in our pallet's configuration trait
+  The `Randomness` trait from `frame_support` requires specifying it with a paramater to replace the `Output` and `BlockNumber` generics.
+  Take a look at [the documentation][randomness-rustdocs] and the source code implementation to understand how this works.
+  For our purposes, we want the output of functions using this trait to be [`Blake2 128-bit hash`][blake2-rustdocs] which you'll notice should already be declared at the top of your working codebase.
 
-The `Randomness` trait from `frame_support` requires specifying it with a paramater to replace the `Output` and `BlockNumber` generics.
-Take a look at [the documentation][randomness-rustdocs] and the source code implementation to understand how this works.
-For our purposes, we want the output of functions using this trait to be [`Blake2 128-bit hash`][blake2-rustdocs] which you'll notice should already be declared at the top of your working codebase.
+  Replace the ACTION #5 line with:
 
-Replace the ACTION #5 line with:
+  ```rust
+  type KittyRandomness: Randomness<Self::Hash, Self::BlockNumber>;
+  ```
 
-```rust
-type KittyRandomness: Randomness<Self::Hash, Self::BlockNumber>;
-```
+1. Specify the actual type in your runtime.
 
-1. #### Specify the actual type in our runtime
+  Given that we have added a new type in the configuration of our pallet, we need to config our runtime to set its concrete type.
+  This could come in handy if ever we want to change the algorithm that `KittyRandomness` is using, without needing to modify where it's used inside our pallet.
 
-Given that we have added a new type in the configuration of our pallet, we need to config our runtime to set its concrete type.
-This could come in handy if ever we want to change the algorithm that `KittyRandomness` is using, without needing to modify where it's used inside our pallet.
+  To showcase this point, we're going to set the `KittyRandomness` type to an instance of [FRAME's `RandomnessCollectiveFlip`][randomness-collective-flip-frame].
+  Conveniently, the Node Template already has an instance of the `RandomnessCollectiveFlip` pallet.
+  
+  Set the `KittyRandomness` type in your runtime (inside `runtime/src/lib.rs`):
 
-To showcase this point, we're going to set the `KittyRandomness` type to an instance of [FRAME's `RandomnessCollectiveFlip`][randomness-collective-flip-frame].
-Conveniently, the Node Template already has an instance of the `RandomnessCollectiveFlip` pallet.
-All you need to do is **set the `KittyRandomness` type in your runtime, inside `runtime/src/lib.rs`**:
+  ```rust
+  impl pallet_kitties::Config for Runtime {
+      type Event = Event;
+        type Currency = Balances;
+      type KittyRandomness = RandomnessCollectiveFlip; // <-- ACTION: add this line.
+  }
+  ```
 
-```rust
-impl pallet_kitties::Config for Runtime {
-    type Event = Event;
-	    type Currency = Balances;
-    type KittyRandomness = RandomnessCollectiveFlip; // <-- ACTION: add this line.
-}
-```
+  Here we have abstracted out the randomness generation implementation (`RandomnessCollectiveFlip`) from its interface (`Randomness<Self::Hash, Self::BlockNumber>` trait).
+  Check out this [how-to guide](/how-to-guides/v3/pallet-design/randomness) on implementing randomness in case you get stuck.
 
-Programming is about abstraction. Here we have abstracted out the randomness generation implementation (`RandomnessCollectiveFlip`) from its interface (`Randomness<Self::Hash, Self::BlockNumber>` trait).
-Check out this [how-to guide](/how-to-guides/v3/pallet-design/randomness) on implementing randomness in case you get stuck.
+1. Generate random DNA
 
-1. #### Generating random DNA
+  Generating DNA is similar to using randomness to randomly assign a gender type.
+  The difference is that we'll be making use of `blake2_128` we imported in the previous part.
+  Replace the ACTION #6 line with:
 
-Generating DNA is similar to using randomness to randomly assign a gender type.
-The difference is that we'll be making use of `blake2_128` we imported in the previous part.
-Replace the ACTION #6 line with:
-
-```rust
-fn gen_dna() -> [u8; 16] {
-    let payload = (
-        T::KittyRandomness::random(&b"dna"[..]).0,
-        <frame_system::Pallet<T>>::block_number(),
-    );
-    payload.using_encoded(blake2_128)
-}
-```
+  ```rust
+  fn gen_dna() -> [u8; 16] {
+      let payload = (
+          T::KittyRandomness::random(&b"dna"[..]).0,
+          <frame_system::Pallet<T>>::block_number(),
+      );
+      payload.using_encoded(blake2_128)
+  }
+  ```
 
 ### Write remaining storage items
-
-1. #### Understanding storage item logic
 
 To easily track all of our kitties, we're going to standardize our logic to use a unique ID as the global key for our storage items.
 This means that a single unique key will point to our Kitty object (i.e. the struct we previously declared).
@@ -654,13 +629,10 @@ For example, from inside a dispatchable function we could check using:
 ensure!(!<Kitties<T>>::exists(new_id), "This new id already exists");
 ```
 
-Our runtime needs to be made aware of:
+Storage items our runtime needs to keep track of:
 
-    - Unique assets, like currency or Kitties (this will be held by a storgae map called `Kitties`)
-    - Ownership of those assets, like account IDs (this will be handled a new storage map called
-    `KittiesOwned`)
-
-1. #### Using a `StorageMap`
+  - Unique assets, like currency or Kitties (this will be held by a storgae map called `Kitties`).
+  - Ownership of those assets, like account IDs (this will be handled a new storage map called `KittiesOwned`).
 
 To create a storage instance for the `Kitty` struct, we'll be using[`StorageMap`][storage-map-kb] &mdash; a hash-map provided to us by FRAME.
 
@@ -679,9 +651,9 @@ pub(super) type Kitties<T: Config> = StorageMap<
 
 Breaking it down, we declare the storage type and assign a `StorageMap` that takes:
 
-    - The [`Twox64Concat`][2x64-rustdocs] hashing algorithm.
-    - A key of type `T::Hash`.
-    - A value of type `Kitty<T>`.
+  - The [`Twox64Concat`][2x64-rustdocs] hashing algorithm.
+  - A key of type `T::Hash`.
+  - A value of type `Kitty<T>`.
 
 The `KittiesOwned` storage item is similar except that we'll be using a `BoundedVec` to keep track of some maximum number of Kitties we'll configure in `runtime/src/lib.s`.
 
@@ -737,7 +709,7 @@ Running into difficulties? Check your solution against the [completed helper cod
 ## Dispatchables, events, and errors
 
 In the previous section of this tutorial, we laid down the foundations geared to manage the ownership of our Kitties &mdash; even though they don't really exist yet!
-In this part of the tutorial, we'll be putting these foundations to use by giving our pallet the ability to create a Kitty using the storage items we've declared.
+In this part we'll be putting these foundations to use by giving our pallet the ability to create a Kitty using the storage items we've declared.
 Breaking things down a little, we're going to write:
 
 - **`create_kitty`**: a dispatchable or publicly callable function allowing an account to mint
@@ -755,7 +727,7 @@ At the end of this part, we'll check that everything compiles without error and 
   text={`
 If you're feeling confident, you can continue building on your codebase from the previous part.
 Otherwise, refer to our starting base code at [here](https://github.com/substrate-developer-hub/substrate-docs/tree/main/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs).
-It also uses various "ACTION" items as a way to assist you through each step.
+It also uses various "ACTION" items as a way to guide you through this section.
   `}
 />
 
@@ -796,14 +768,14 @@ All we need to know here is that they're a useful feature of FRAME that minimize
 
 #### Weights
 
-As per the requirement for `#[pallet::call]` described in the its documentation, every dispatchable function must have an associated weight to it.
+As per the requirement for `#[pallet::call]` described in its documentation, every dispatchable function must have an associated weight to it.
 Weights are an important part of developing with Substrate as they provide safe-guards around the amount of computation to fit in a block at execution time.
 
 [Substrate's weighting system][weights-kb] forces developers to think about the computational complexity each [extrinsic][extrinsics-kb] carries before it is called.
 This allows a node to account for worst case execution time, avoiding lagging the network with extrinsics that may take longer than the specified block time.
-Weights are also intimately linked to the [fee system][txn-fees-kb] for a signed extrinsic.
+Weights are also intimately linked to the [fee system][txn-fees-kb] for any signed extrinsic.
 
-For this simple application, we're going to default all weights to 100.
+As this is just a tutorial, we're going to default all weights to 100 to keep things simple.
 
 Assuming you've now replaced the contents of `pallets/kitties/src/lib.rs` with [the helper file](https://github.com/substrate-developer-hub/substrate-docs/tree/main/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs) for this section, find ACTION #1 and replace it with the following code:
 
@@ -829,18 +801,6 @@ In order to use `log::info`, add this to your pallet's `Cargo.toml` file:
 default-features = false
 version = '0.4.14'
 ```
-
-<br />
-<Message
-  type="gray"
-  title='Why "DispatchResult" and not "DispatchResultWithPostInfo"?'
-  text={`
-In \`create_kitty\` our return was of type \`DispatchResult\`. Since \`mint()\` is a helper for
-\`create_kitty\`, we don't need to overwrite \`PostDispatchInfo\`, we can use a return type of
-[\`DispatchResult\`](/rustdocs/latest/frame_support/dispatch/type.DispatchResult.html), its unaugmented 
-version.
-  `}
-/>
 
 ### Write the `mint()` function
 
@@ -941,45 +901,31 @@ Self::deposit_event(Event::Success(var_time, var_day));
 ```
 
 In order to use events inside our pallet, we need to add a new associated type `Event` inside our pallet's configuration trait `Config`.
-Additionally &mdash; just as when adding any type to our pallet's `Config` trait &mdash; we also need to define it in our runtime `/runtime/src/lib.rs`.
+Additionally &mdash; just as when adding any type to our pallet's `Config` trait &mdash; we also need to define it in our runtime `runtime/src/lib.rs`.
 
 This pattern is the same as when we added the `KittyRandomness` type to our pallet's configuration trait [earlier in this tutorial](#implement-on-chain-randomness) and has already been included from the initial scaffolding of our codebase:
 
 ```rust
-  /// Configure the pallet by specifying the parameters and types it depends on.
-  #[pallet::config]
-  pub trait Config: frame_system::Config {
-      /// Because this pallet emits events, it depends on the runtime's definition of an event.
-      type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
-      //--snip--//
+/// Configure the pallet by specifying the parameters and types it depends on.
+#[pallet::config]
+pub trait Config: frame_system::Config {
+  /// Because this pallet emits events, it depends on the runtime's definition of an event.
+  type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+  //--snip--//
   }
 ```
-
-<br />
-<Message
-  type={`yellow`}
-  title={`Information`}
-  text={`
-Notice that each event deposit is meant to be informative which is why it carries the various types
-associated with it.\n
-It's good practice to get in the habit of documenting your event declarations so that your code is
-easy to read. It is convention to document events as such:\n
-\`/// Description. [types]\`
-Learn more about events [here](/v3/runtime/events-and-errors).
-  `}
-/>
 
 Declare your pallet events by replacing the ACTION #3 line with:
 
 ```rust
-  /// A new Kitty was sucessfully created. \[sender, kitty_id\]
-  Created(T::AccountId, T::Hash),
-  /// Kitty price was sucessfully set. \[sender, kitty_id, new_price\]
-  PriceSet(T::AccountId, T::Hash, Option<BalanceOf<T>>),
-  /// A Kitty was sucessfully transferred. \[from, to, kitty_id\]
-  Transferred(T::AccountId, T::AccountId, T::Hash),
-  /// A Kitty was sucessfully bought. \[buyer, seller, kitty_id, bid_price\]
-  Bought(T::AccountId, T::AccountId, T::Hash, BalanceOf<T>),
+/// A new Kitty was sucessfully created. \[sender, kitty_id\]
+Created(T::AccountId, T::Hash),
+/// Kitty price was sucessfully set. \[sender, kitty_id, new_price\]
+PriceSet(T::AccountId, T::Hash, Option<BalanceOf<T>>),
+/// A Kitty was sucessfully transferred. \[from, to, kitty_id\]
+Transferred(T::AccountId, T::AccountId, T::Hash),
+/// A Kitty was sucessfully bought. \[buyer, seller, kitty_id, bid_price\]
+Bought(T::AccountId, T::AccountId, T::Hash, BalanceOf<T>),
 ```
 
 We'll be using most of these events in the last section of this tutorial.
@@ -1003,7 +949,7 @@ for this part) you'll need to add \`Ok(())\` and properly close the \`create_kit
 
 ### Error handling
 
-FRAME provides us with an error handling system using [`[#pallet::errors]`][errors-kb] which allows us to specify errors for our pallet and use them across our pallet's functions.
+FRAME provides us with an error handling system using [`[#pallet::error]`][errors-kb] which allows us to specify errors for our pallet and use them across our pallet's functions.
 
 Declare all possible errors using the provided FRAME macro under `#[pallet::error]`, replace line ACTION #5a with:
 
@@ -1051,50 +997,26 @@ check your code!
 />
 
 Did that build fine? Congratulations! That's the core functionality of our Kitties pallet.
-In the next step you'll be able to see everything you've built so far in action.
+In the next section you'll be able to see everything you've built so far in action.
 
 ### Testing with Polkadot-JS Apps UI
 
-Assuming that you successfully built your chain, let's run it and use the [PolkadotJS Apps UI](https://polkadot.js.org/apps/#/explorer) to interact with it.
+1. Run your chain and use the [PolkadotJS Apps UI](https://polkadot.js.org/apps/#/explorer) to interact with it.
+In your project directory, run:
 
-In your chain's project directory, run:
+  ```bash
+  ./target/release/node-kitties --tmp --dev
+  ```
 
-```bash
-./target/release/node-kitties --tmp --dev
-```
+  By doing this, we're specifying to run a temporary chain in developer mode, so as not to need to purge storage each time we want to start a fresh chain.
+  You should be seeing block finalization happening in your terminal. 
 
-By doing this, we're specifying to run a temporary chain in developer mode, so as not to need to purge storage each time we want to start a fresh chain.
+1. Head over to [Polkadot.js Apps UI][polkadotjsapps].
 
-Assuming that blocks are being finalized (which you should be able to see from the terminal in which you ran the above command), head over to [Polkadot.js Apps UI][polkadotjsapps].
-
-**Follow these steps:**
-
-1. Check that you're connected to the Local Node.
-   Click on the top left circular network icon, open the "Development" section, and choose "Local Node".
+1. Click on the top left circular network icon, open the "Development" section, and choose "Local Node".
    Your node is default to be `127.0.0.1.:9944`.
 
-1. Tell the Apps about your custom types.
-   This requires you to navigate to the "_Settings_" -> "_Developer_" section, and then paste in the editor the following custom types (in JSON format):
-
-```json
-{
-  "Gender": {
-    "_enum": ["Male", "Female"]
-  },
-  "Kitty": {
-    "dna": "[u8; 16]",
-    "price": "Option<Balance>",
-    "gender": "Gender",
-    "ownder": "AccountId"
-  }
-}
-```
-
-> The reason we need this is because Polkadot-JS Apps isn't designed to read custom types by default.
-> By adding them, it can properly decode each of our storage items that rely on custom types.
-> Add this in a file called `types.json` in your projects `runtime` folder.
-
-1. Now go to: _"Developer"_ -> _"Extrinsics"_ and submit a signed extrinsic using _substrateKitties_ by calling the `createKitty()` dispatchable.
+1. Go to: _"Developer"_ -> _"Extrinsics"_ and submit a signed extrinsic using _substrateKitties_ by calling the `createKitty` dispatchable.
    Make 3 different transactions from Alice, Bob and Charlie's accounts.
 
 1. Check for the associated event _"Created"_ by going to "_Network_" -> "_Explorer_".
@@ -1102,7 +1024,6 @@ Assuming that blocks are being finalized (which you should be able to see from t
 
 1. Check your newly created Kitty's details by going to "_Developer_" -> "_Chain State_".
    Select the _substrateKitties_ pallet and query `Kitties(Hash): Kitty`.
-   **Note:** You'll notice that this is actually querying all of your pallet's storage items!
 
    Be sure to uncheck the "include option" box and you should be able to see the details of your newly minted Kitty in the following format:
 
@@ -1117,7 +1038,7 @@ Assuming that blocks are being finalized (which you should be able to see from t
          dna: 0xaf2f2b3f77e110a56933903a38cde1eb,
          price: null,
          gender: Female,
-         ownder: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+         owner: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
        }
      ]
    ]
@@ -1125,26 +1046,9 @@ Assuming that blocks are being finalized (which you should be able to see from t
 
 1. Check that other storage items correctly reflect the creation of additional Kitties.
 
-<Message
-  type="green"
-  title="Congratulations!"
-  text={`
-You're pretty much able to take it from here at this point! We've learnt how to implement the key
-parts of what powers a FRAME pallet and how to put them to use. In the next section we'll be building
-on our knowledge by adding more capabilities to our pallet.\n
-To recap, in this part of the tutorial you've learnt how to:\n
-- Distinguish between implementing a dispatchable function and a private helper function.
-- Use \`#[pallet::call]\`, \`#[pallet::event]\` and \`#[pallet::error]\`.
-- Implement basic error checking with FRAME.
-- Update values in storage with safety checks.
-- Implement FRAME events and use them in a function.
-- Query storage items and chain state using the PolkadotJS Apps UI.
-  `}
-/>
-
 ## Interacting with your Kitties
 
-Up until this point in the tutorial, we've built a chain capable of only creating and tracking the ownership of Kitties.
+Up until this point in the tutorial, you've built a chain capable of only creating and tracking the ownership of Kitties.
 Now that that's done, we want to make our runtime more like a game by introducing other functions like buying and selling Kitties.
 In order to achieve this, we'll first need to enable users to mark and update the price of their Kitties.
 Then we can add functionality to enable users to transfer, buy, and breed Kitties.
@@ -1303,9 +1207,9 @@ pub fn transfer(
 By now the above pattern should be familiar.
 We always check that the transaction is signed; then we verify that:
 
-1. The Kitty being transferred is owned by the sender of this transaction;
-2. The Kitty is not transferred to its owner (a redundant operation);
-3. The recipient has the capacity to receive one more kitty;
+1. The Kitty being transferred is owned by the sender of this transaction.
+2. The Kitty is not transferred to its owner (a redundant operation).
+3. The recipient has the capacity to receive one more kitty.
 
 Lastly we call the `transfer_kitty_to` helper to update all storage items appropriately.
 
@@ -1360,14 +1264,12 @@ Otherwise all changes are discarded.
 
 ### Buy a Kitty
 
-#### A. Check a Kitty is for sale
-
 We'll need to ensure two things before we can allow the user of this function to purchase a Kitty:
 
-1. Check that the Kitty is for sale;
-2. Check whether the Kitty's current price is within the user's budget and whether the user has enough free balance.
+- Check that the Kitty is for sale.
+- Check whether the Kitty's current price is within the user's budget and whether the user has enough free balance.
 
-Replace line ACTION #6:
+Replace line ACTION #6 to check whether a Kitty is for sale:
 
 ```rust
 // Check the kitty is for sale and the kitty ask price <= bid_price
@@ -1393,12 +1295,7 @@ ensure!((to_owned.len() as u32) < T::MaxKittyOwned::get(), <Error<T>>::ExceedMax
 let seller = kitty.owner.clone();
 ```
 
-#### B. Making a payment
-
-In [Step 2](#2-transfer-a-kitty), we added the functions necessary to transfer the _ownership_ of our Kitties.
-But we haven't yet touched on the currrency system associated to our pallet.
-
-In this step we'll learn how to use [FRAME's Currency trait][currency-frame-rustdocs] to adjust account balances using its [`transfer` method][transfer-currency-rustdocs].
+We'll use [FRAME's Currency trait][currency-frame-rustdocs] to adjust account balances using its [`transfer` method][transfer-currency-rustdocs].
 It's useful to understand why it's important to use the `transfer` method in particular and how we'll be accessing it:
 
 - The reason we'll be using it is to ensure our runtime has the same understanding of currency throughout the pallets it interacts with.
@@ -1407,14 +1304,14 @@ It's useful to understand why it's important to use the `transfer` method in par
 - Conveniently, it handles a [`Balance`][currency-balances-rustdocs] type, making it compatible with `BalanceOf` type we created for `kitty.price`.
   Take a look at how the `transfer` function we'll be using [is structured][currency-transfer-rustdocs]:
 
-  ```rust
-    fn transfer(
-        source: &AccountId,
-        dest: &AccountId,
-        value: Self::Balance,
-        existence_requirement: ExistenceRequirement
-    ) -> DispatchResult
-  ```
+```rust
+  fn transfer(
+      source: &AccountId,
+      dest: &AccountId,
+      value: Self::Balance,
+      existence_requirement: ExistenceRequirement
+  ) -> DispatchResult
+```
 
 Now we can make use of the `Currency` type in our pallet's `Config` trait and `ExistenceRequirement` that we [initially started with in the first section](#write-out-pallet_kitties-scaffold).
 
@@ -1438,7 +1335,7 @@ Self::deposit_event(Event::Bought(buyer, seller, kitty_id, bid_price));
   text={`
 Both of the above operations, \`T::Currency::transfer()\`, and \`Self::transfer_kitty_to()\` could
 fail which is why we check for the returned result in each case. If \`Err\` is returned, we also return from the
-function immediately. In order to keep the storage consistent, we also annotate this function as
+function immediately. In order to keep the storage consistent with these potential changes, we also annotate this function as
 \`#[transactional]\`.
 `}
 />
@@ -1542,7 +1439,7 @@ After all of these actions, confirm that all users have the correct number of Ki
 You've successfully created the backend of a fully functional Substrate chain capable of creating
 and managing Substrate Kitties. The basic capabilities of our Kitties application could also be 
 abstracted to other NFT-like use cases. Most importantly, at this point in the tutorial you should 
-have all the knowledge you need to start creating your own pallet logics and dispatchable functions.
+have all the knowledge you need to start creating your own pallet logic and dispatchable functions.
 `}
 />
 

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -354,7 +354,7 @@ pub mod pallet {
 	use sp_io::hashing::blake2_128;
 
 	#[cfg(feature = "std")]
-	use serde::{Deserialize, Serialize};
+	use frame_support::serde::{Deserialize, Serialize};
 
 	// ACTION #1: Write a Struct to hold Kitty information.
 
@@ -524,14 +524,6 @@ To create it, you'll build out the following parts:
 
   Notice the use of the [derive macro][derive-macro-rust] which must precede the enum declaration.
   This wraps our enum in the data structures it will need to interface with other types in our runtime.
-
-1. In order to use `Serialize` and `Deserialize`, you will need to add the `serde` crate in `pallets/kitties/Cargo.toml`:
-
-  ```toml
-  [dependencies.serde]
-  default-features = false
-  version = '1.0.119'
-  ```
 
   Great, we now know how to create a custom struct.
   But what about providing a way for a Kitty struct to be _assigned_ a gender value?

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -1107,7 +1107,7 @@ Assuming that blocks are being finalized (which you should be able to see from t
    Be sure to uncheck the "include option" box and you should be able to see the details of your newly minted Kitty in the following format:
 
    ```json
-   kitties.kitties: Option<Kitty>
+   substrateKitties.kitties: Option<Kitty>
    [
      [
        [

--- a/v3/tutorials/11-kitties-workshop/b-kitties-frontend/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/b-kitties-frontend/index.mdx
@@ -21,20 +21,16 @@ clone the Kitty node solution from [this branch](https://github.com/substrate-de
 and use that to follow this part of the tutorial.`}
 />
 
-In Part I we created all of the back-end portion of our Kitties application. In this part, it's
-time to build a user interface which can access and interact with our custom storage items and
-functions. We'll be using:
+In Part I we created all of the back-end portion of our Kitties application. 
+In this part, you'll build a user interface which can access and interact with our custom storage items and functions. 
+We'll be using:
 
-- [Polkadot-JS API](https://polkadot.js.org/docs/api/)
+- [Polkadot-JS API](https://polkadot.js.org/docs/api/).
 - The [Substrate Front-end Template](https://github.com/substrate-developer-hub/substrate-front-end-template), a [React app](https://reactjs.org/)
   that wraps Polkadot-JS API to make it easier to make RPC's to our chain's runtime.
 - A [library for generating Cat avatars](https://framagit.org/Deevad/cat-avatar-generator),
   licensed under [CC-By 4.0](https://creativecommons.org/licenses/by/4.0/) attribution. Thank you
   [David Revoy's](https://framagit.org/Deevad) for making this available.
-
-In Part 2, there will only be two main sections: the first focussing on setting up the Front-end
-Template and the second focussing on building custom React components that can interact with our
-Kitty node.
 
 In case you get stuck, the complete solution for this part of the tutorial
 can be found [here](https://github.com/substrate-developer-hub/substrate-front-end-template/tree/tutorials/kitties).
@@ -96,54 +92,24 @@ You should see a tab open up with the front-end template displaying basic featur
 Notice that it comes with a number of prebuilt components to provide basic interactions with a Substrate
 Node Template blockchain.
 
-### Specifying types
-
-An important starting point when setting up a custom front-end for a Substrate node is creating a
-JSON file with all of the node's custom types. These are types that we created in our pallet that
-the Polkadot JS API doesn't know about. Learn more about [Extending types](https://polkadot.js.org/docs/api/start/types.extend/)
-in the Polkadot JS API documentation.
-
-In our case, we have two custom types we'll need to add: the `Gender` enum and the `Kitty` struct.
-
-To do this, go into `src/config/types.json` and replace the whole file with:
-
-```json
-{
-  "Gender": {
-    "_enum": ["Male", "Female"]
-  },
-  "Kitty": {
-    "dna": "[u8; 16]",
-    "price": "Option<Balance>",
-    "gender": "Gender",
-    "owner": "AccountId"
-  }
-}
-```
-
 ### Sketching out our components
 
-[Substrate Frontend Template][substrate-frontend-template] components use Polkadot-JS API and an
-RPC endpoints to communicate with a Substrate node. This allows us to use it to read storage items,
-and make extrinsics by calling our pallet's dispatchable functions. Before we get to that, let's
-sketch out the different parts of our application.
+[Substrate Frontend Template][substrate-frontend-template] components use Polkadot-JS API and RPC endpoints to communicate with a Substrate node. 
+This allows us to use it to read storage items, and make extrinsics by calling our pallet's dispatchable functions. 
+Before we get to that, let's sketch out the different parts of our application.
 
 We'll be building out a total of 3 components:
 
-1. `Kitties.js`: this will render the Kitty pane, and contains the logics of fetching all kitties
-   information from the connecting Substrate node.
+1. `Kitties.js`: this will render the Kitty pane, and contains the logics of fetching all kitties information from the connecting Substrate node.
 
-2. `KittyCards.js`: this will render a React card component containing a Kitty's relevant
-   information, avatar and buttons to interact with it.
+2. `KittyCards.js`: this will render a React card component containing a Kitty's relevant information, avatar and buttons to interact with it.
 
-3. `KittyAvatar.js`: this will handle the logic to map Kitty DNA to the library of PNGs we're using
-   to create unique Kitty avatars.
+3. `KittyAvatar.js`: this will handle the logic to map Kitty DNA to the library of PNGs we're using to create unique Kitty avatars.
 
 ### Polkadot JS API Basics
 
-Before moving on to the next section, we reccommend you read a little Polkadot JS API documentation
-to understand the basics of how we will be querying storage and triggering transactions. Here are
-some good resources:
+We reccommend you read a little Polkadot JS API documentation to understand the basics of how we will be querying storage and triggering transactions. 
+Here are some good resources:
 
 - [Basics and Metadata](https://polkadot.js.org/docs/api/start/basics)
 - [RPC queries](https://polkadot.js.org/docs/api/start/api.rpc)
@@ -156,100 +122,119 @@ some good resources:
 
 ## Creating custom components
 
-### Create `Kitties.js`
-
-This is the component that will get rendered by `Apps.js`, the top-most level component. So it does
-the heavy lifting, with the help of `KittyAvatar.js` and `KittCards.js`.
+`Kitties.js` is the component that will get rendered by `Apps.js`, the top-most level component. 
+So it does the heavy lifting, with the help of `KittyAvatar.js` and `KittCards.js`.
 
 1. Start by creating a file called `Kitties.js` in `src` and paste the following imports:
 
-````js
-import React, { useEffect, useState } from 'react';
-import { Form, Grid } from 'semantic-ui-react';
+  ```js
+  import React, { useEffect, useState } from 'react';
+  import { Form, Grid } from 'semantic-ui-react';
 
-import { useSubstrate } from './substrate-lib';
-import { TxButton } from './substrate-lib/components';
+  import { useSubstrate } from './substrate-lib';
+  import { TxButton } from './substrate-lib/components';
 
-import KittyCards from './KittyCards';
+  import KittyCards from './KittyCards';
   ```
 
-The way our custom components make use of Polkadot-JS API is by using `substrate-lib`, which is a
-wrapper around [Polkadot JS API instance](https://polkadot.js.org/docs/api/start/create/) and
-allows us to retrieve account keys from the [Polkadot-JS keyring](https://polkadot.js.org/docs/api/start/keyring).
-This is why we use `useSubstrate` which is exported by `src/substrate-lib/SubstrateContext.js` and
-used to create the wrapper.
+  The way our custom components make use of Polkadot-JS API is by using `substrate-lib`, which is a wrapper around [Polkadot JS API instance](https://polkadot.js.org/docs/api/start/create/) and allows us to retrieve account keys from the [Polkadot-JS keyring](https://polkadot.js.org/docs/api/start/keyring).
+  This is why we use `useSubstrate` which is exported by `src/substrate-lib/SubstrateContext.js` and used to create the wrapper.
 
 1. Proceed by pasting in the following code snippet:
 
-```js
-// Construct a Kitty ID from storage key
-const convertToKittyHash = entry =>
-  `0x${entry[0].toJSON().slice(-64)}`;
+  ```js
+  // Construct a Kitty ID from storage key
+  const convertToKittyHash = entry =>
+    `0x${entry[0].toJSON().slice(-64)}`;
 
-// Construct a Kitty object
-const constructKitty = (hash, { dna, price, gender, owner }) => ({
-  id: hash,
-  dna,
-  price: price.toJSON(),
-  gender: gender.toJSON(),
-  owner: owner.toJSON()
-});
+  // Construct a Kitty object
+  const constructKitty = (hash, { dna, price, gender, owner }) => ({
+    id: hash,
+    dna,
+    price: price.toJSON(),
+    gender: gender.toJSON(),
+    owner: owner.toJSON()
+  });
 
-// Use React hooks
-export default function Kitties (props) {
-  const { api, keyring } = useSubstrate();
-  const { accountPair } = props;
+  // Use React hooks
+  export default function Kitties (props) {
+    const { api, keyring } = useSubstrate();
+    const { accountPair } = props;
 
-  const [kittyHashes, setKittyHashes] = useState([]);
-  const [kitties, setKitties] = useState([]);
-  const [status, setStatus] = useState('');
-// snip
-````
+    const [kittyHashes, setKittyHashes] = useState([]);
+    const [kitties, setKitties] = useState([]);
+    const [status, setStatus] = useState('');
+  // snip
+  ```
 
-The above code handles a few important things for our application:
+  The above code handles a few important aspects of our front-end application:
 
-    - `convertToKittyHash` helps construct a Kitty ID from its storage key
-    - `constructKitty` is a function to hold all Kitty objects
-    - `Kitties` enables us to subscribe to chain storage item changes and use the `useEffect`
-    React hook to update the state of our other components.
+    - `convertToKittyHash` helps construct a Kitty ID from its storage key.
+    - `constructKitty` is a function to hold all Kitty objects.
+    - `Kitties` enables us to subscribe to chain storage item changes and use the `useEffect` React hook to update the state of our other components.
 
-There are two things our app needs to subscribe to: storage changes in the amount of Kitties and
-changes in Kitty objects. To do this we'll create [a subscription](https://reactjs.org/docs/hooks-reference.html#useeffect)
-function for each.
+  There are two things our app needs to subscribe to: storage changes in the amount of Kitties and changes in Kitty objects. 
+  To do this we'll create [a subscription](https://reactjs.org/docs/hooks-reference.html#useeffect) function for each.
 
-We'll use `api.query.substrateKitties.kittyCnt` to listen for a change in the amount of Kitties,
-which will query `KittyCnt` from our Kitties pallet storage item. Then,
-we'll use the `entries()` method from Polkadot-JS API to get Kitty IDs and transform them
-with the `convertToKittyHash` function.
+  We'll use `api.query.substrateKitties.kittyCnt` to listen for a change in the amount of Kitties, which will query `KittyCnt` from our Kitties pallet storage item. 
+  Then, we'll use the `entries()` method from Polkadot-JS API to get Kitty IDs and transform them with the `convertToKittyHash` function.
 
-1. To enable this, paste the following snippet:
+1. Paste the following snippet to enable this:
 
-```js
-// Subscription function for setting Kitty IDs
-const subscribeKittyCnt = () => {
-  let unsub = null
+  ```js
+  // Subscription function for setting Kitty IDs
+  const subscribeKittyCnt = () => {
+    let unsub = null
 
-  const asyncFetch = async () => {
-    // Query KittyCnt from runtime
-    unsub = await api.query.substrateKitties.kittyCnt(async cnt => {
-      // Fetch all Kitty objects using entries()
-      const entries = await api.query.substrateKitties.kitties.entries()
-      // Retrieve only the Kitty ID and set to state
-      const hashes = entries.map(convertToKittyHash)
-      setKittyHashes(hashes)
-    })
+    const asyncFetch = async () => {
+      // Query KittyCnt from runtime
+      unsub = await api.query.substrateKitties.kittyCnt(async cnt => {
+        // Fetch all Kitty objects using entries()
+        const entries = await api.query.substrateKitties.kitties.entries()
+        // Retrieve only the Kitty ID and set to state
+        const hashes = entries.map(convertToKittyHash)
+        setKittyHashes(hashes)
+      })
+    }
+
+    asyncFetch()
+
+    // return the unsubscription cleanup function
+    return () => {
+      unsub && unsub()
+    }
   }
+  ```
 
-  asyncFetch()
+1. Similarly for `subscribeKitties`, paste the following code snippet:
 
-  // return the unsubscription cleanup function
-  return () => {
-    unsub && unsub()
+  ```js
+  // Subscription function to construct a Kitty object
+  const subscribeKitties = () => {
+    let unsub = null
+
+    const asyncFetch = async () => {
+      // Get Kitty objects from storage
+      unsub = await api.query.substrateKitties.multi(kittyHashes, kitties => {
+        // Create an array of Kitty objects from `constructKitty`
+        const kittyArr = kitties.map((kitty, ind) =>
+          constructKitty(kittyHashes[ind], kitty.value)
+        )
+        // Set the array of Kitty objects to state
+        setKitties(kittyArr)
+      })
+    }
+
+    asyncFetch()
+
+    // return the unsubscription cleanup function
+    return () => {
+      unsub && unsub()
+    }
   }
-}
-```
+  ```
 
-{' '}
+
 <br />
 <Message
   type={`green`}
@@ -258,82 +243,52 @@ const subscribeKittyCnt = () => {
   \`entries()\` is a Polkadot-JS API function that gives us the entire storage map of \`Kitties\` that
   we defined in Part I. If there's nothing in the storage, it returns \`None\`. All functions that
   interact with a chain will always return a **Promise** in Polkadot-JS API. So we wait for it to be
-  resolved, and return us all the map keys and objects.\n
-  You can see this in action if you go to the console of your browser running a node Front-end and
-  entering \`entries\`, or get the first Kitty object in storage by doing: \`entries[0][1].toJSON()\`.
+  resolved, and return all the map keys and objects.\n
+  You can see this in action if you go to the console of your browser running a node and Front-end and
+  entering \`entries\`. For example, you can get the first Kitty object in storage by doing: \`entries[0][1].toJSON()\`.
     `}
 />
 
-1. Similarly for `subscribeKitties`, paste the following code snippet:
+### Fetching node data 
 
-```js
-// Subscription function to construct a Kitty object
-const subscribeKitties = () => {
-  let unsub = null
+1. Use `convertToKittyHash` helper function (from step 2) in the subscription function to transform an entry to its corresponding hash:
 
+  ```js
   const asyncFetch = async () => {
-    // Get Kitty objects from storage
-    unsub = await api.query.substrateKitties.multi(kittyHashes, kitties => {
-      // Create an array of Kitty objects from `constructKitty`
-      const kittyArr = kitties.map((kitty, ind) =>
-        constructKitty(kittyHashes[ind], kitty.value)
-      )
-      // Set the array of Kitty objects to state
-      setKitties(kittyArr)
+    unsub = await api.query.substrateKitties.kitties.kittyCnt(async cnt => {
+      // Fetch all kitty keys
+      const entries = await api.query.substrateKitties.kitties.entries()
+      const hashes = entries.map(convertToKittyHash)
+      setKittyHashes(hashes)
     })
   }
+  ```
 
-  asyncFetch()
-
-  // return the unsubscription cleanup function
-  return () => {
-    unsub && unsub()
-  }
-}
-```
-
-A Substrate [storage item key](/v3/advanced/storage#storage-value-keys) is composed of a concatenation
-of the hash of the pallet name, the hash of the storage item name, and finally the hash of the key
-used in the map. Now we want to extract only the key for the map, so we extract the last 64 bytes
-out in our `convertToKittyHash` function.
-
-1. Use `convertToKittyHash` helper function (declared at step 2) in the subscription function to transform an entry to its corresponding hash:
-
-```js
-const asyncFetch = async () => {
-  unsub = await api.query.substrateKitties.kitties.kittyCnt(async cnt => {
-    // Fetch all kitty keys
-    const entries = await api.query.substrateKitties.kitties.entries()
-    const hashes = entries.map(convertToKittyHash)
-    setKittyHashes(hashes)
-  })
-}
-```
-
-In `asyncFetch` we have subscribed to the Kitties storage. When the component is teared down, we
-want to make sure the subscription is cleaned up (unsubscribed). So we return a clean up function
-for the effect hook. Refer to
-[Effects with Cleanup](https://reactjs.org/docs/hooks-effect.html#effects-with-cleanup) to learn more
-about cleanup functions.
+  A Substrate [storage item key](/v3/advanced/storage#storage-value-keys) is composed of a concatenation of the hash of the pallet name, the hash of the storage item name, and finally the hash of the key used in the map. 
+  Now we want to extract only the key for the map, so we use `convertToKittyHash` to extract the last 64 bytes which will give us our Kitty ID.
 
 1. Return the clean-up function:
 
-```js
-  // return the unsubscription cleanup function
-    return () => {
-      unsub && unsub();
+  ```js
+    // return the unsubscription cleanup function
+      return () => {
+        unsub && unsub();
+      };
     };
-  };
-```
+  ```
 
-1. Now all that's left to do for our component to listen for changes in our node's runtime storage is
-   to pass in `subscribeKittyCnt` and `subscribeKitties` to React's `useEffect` function. Add these
-   lines to enable this:
+  In `asyncFetch` we have subscribed to the Kitties storage. 
+  When the component is teared down, we want to make sure the subscription is cleaned up (unsubscribed). 
+  So we return a clean up function for the effect hook. 
+  Refer to [Effects with Cleanup](https://reactjs.org/docs/hooks-effect.html#effects-with-cleanup) to learn more about cleanup functions.
 
-```js
-useEffect(subscribeKittyCnt, [api, keyring])
-useEffect(subscribeKitties, [api, kittyHashes])
-```
+1. Now all that's left to do for our component to listen for changes in our node's runtime storage is to pass in `subscribeKittyCnt` and `subscribeKitties` to React's `useEffect` function. 
+ Add these lines to enable this:
+
+  ```js
+  useEffect(subscribeKittyCnt, [api, keyring])
+  useEffect(subscribeKitties, [api, kittyHashes])
+  ```
 
 Congratulations! We have setup the ground work of accessing the chain and saving all Kitty information
 internally using React. We'll come back to the `Kitties.js` component later once we create all the missing
@@ -347,77 +302,75 @@ Since it's mostly all Javascript, we won't be going into much detail.
 1. Create a file called `KittyAvatar.js` in the `src` folder of your project and paste in the following
    code:
 
-```js
-import React from 'react'
+  ```js
+  import React from 'react'
 
-// Generate an array [start, start + 1, ..., end] inclusively
-const genArray = (start, end) =>
-  Array.from(Array(end - start + 1).keys()).map(v => v + start)
+  // Generate an array [start, start + 1, ..., end] inclusively
+  const genArray = (start, end) =>
+    Array.from(Array(end - start + 1).keys()).map(v => v + start)
 
-const IMAGES = {
-  accessory: genArray(1, 20).map(
-    n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/accessorie_${n}.png`
-  ),
-  body: genArray(1, 15).map(
-    n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/body_${n}.png`
-  ),
-  eyes: genArray(1, 15).map(
-    n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/eyes_${n}.png`
-  ),
-  mouth: genArray(1, 10).map(
-    n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/mouth_${n}.png`
-  ),
-  fur: genArray(1, 10).map(
-    n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/fur_${n}.png`
-  ),
-}
-
-const dnaToAttributes = dna => {
-  const attribute = (index, type) =>
-    IMAGES[type][dna[index] % IMAGES[type].length]
-
-  return {
-    body: attribute(0, 'body'),
-    eyes: attribute(1, 'eyes'),
-    accessory: attribute(2, 'accessory'),
-    fur: attribute(3, 'fur'),
-    mouth: attribute(4, 'mouth'),
+  const IMAGES = {
+    accessory: genArray(1, 20).map(
+      n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/accessorie_${n}.png`
+    ),
+    body: genArray(1, 15).map(
+      n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/body_${n}.png`
+    ),
+    eyes: genArray(1, 15).map(
+      n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/eyes_${n}.png`
+    ),
+    mouth: genArray(1, 10).map(
+      n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/mouth_${n}.png`
+    ),
+    fur: genArray(1, 10).map(
+      n => `${process.env.PUBLIC_URL}/assets/KittyAvatar/fur_${n}.png`
+    ),
   }
-}
 
-const KittyAvatar = props => {
-  const outerStyle = { height: '160px', position: 'relative', width: '50%' }
-  const innerStyle = {
-    height: '150px',
-    position: 'absolute',
-    top: '3%',
-    left: '50%',
+  const dnaToAttributes = dna => {
+    const attribute = (index, type) =>
+      IMAGES[type][dna[index] % IMAGES[type].length]
+
+    return {
+      body: attribute(0, 'body'),
+      eyes: attribute(1, 'eyes'),
+      accessory: attribute(2, 'accessory'),
+      fur: attribute(3, 'fur'),
+      mouth: attribute(4, 'mouth'),
+    }
   }
-  const { dna } = props
 
-  if (!dna) return null
+  const KittyAvatar = props => {
+    const outerStyle = { height: '160px', position: 'relative', width: '50%' }
+    const innerStyle = {
+      height: '150px',
+      position: 'absolute',
+      top: '3%',
+      left: '50%',
+    }
+    const { dna } = props
 
-  const cat = dnaToAttributes(dna)
-  return (
-    <div style={outerStyle}>
-      <img alt="body" src={cat.body} style={innerStyle} />
-      <img alt="fur" src={cat.fur} style={innerStyle} />
-      <img alt="mouth" src={cat.mouth} style={innerStyle} />
-      <img alt="eyes" src={cat.eyes} style={innerStyle} />
-      <img alt="accessory" src={cat.accessory} style={innerStyle} />
-    </div>
-  )
-}
+    if (!dna) return null
 
-export default KittyAvatar
-```
+    const cat = dnaToAttributes(dna)
+    return (
+      <div style={outerStyle}>
+        <img alt="body" src={cat.body} style={innerStyle} />
+        <img alt="fur" src={cat.fur} style={innerStyle} />
+        <img alt="mouth" src={cat.mouth} style={innerStyle} />
+        <img alt="eyes" src={cat.eyes} style={innerStyle} />
+        <img alt="accessory" src={cat.accessory} style={innerStyle} />
+      </div>
+    )
+  }
 
-Notice that the only properties being passed in is `dna`, which will be passed from `KittyCards.js`.
+  export default KittyAvatar
+  ```
+
+  Notice that the only properties being passed in is `dna`, which will be passed from `KittyCards.js`.
 
 1. The logic in this component is based on a specific Cat Avatar library of PNGs.
-   [Download it](https://framagit.org/Deevad/cat-avatar-generator/-/tree/master/avatars/cat)
-   and paste the contents of `avatars/cat` inside a new folder called "KittyAvatar" in your project's `public/assets`
-   folder.
+   [Download it](https://framagit.org/Deevad/cat-avatar-generator/-/tree/master/avatars/cat) and paste the contents of `avatars/cat` inside a new folder called "KittyAvatar" in your project's `public/assets` folder.
 
 1. Save and close `KittyAvatar.js`.
 
@@ -434,40 +387,40 @@ Our `KittyCards.js` component will have three sections to it:
 
 1. As a preliminary step, create a new file called `KittyCards.js` and add the following imports:
 
-```js
-import React from 'react'
-import {
-  Button,
-  Card,
-  Grid,
-  Message,
-  Modal,
-  Form,
-  Label,
-} from 'semantic-ui-react'
+  ```js
+  import React from 'react'
+  import {
+    Button,
+    Card,
+    Grid,
+    Message,
+    Modal,
+    Form,
+    Label,
+  } from 'semantic-ui-react'
 
-import KittyAvatar from './KittyAvatar'
-import { TxButton } from './substrate-lib/components'
-```
+  import KittyAvatar from './KittyAvatar'
+  import { TxButton } from './substrate-lib/components'
+  ```
 
-Let's outline what the `TransferModal` will do. Conveniently, the Substrate Front-end Template comes
-with a component called `TxButton` which is a useful way to include a transfer button that interacts
-with a node. This component will allow us to send a transaction into our node and trigger a
-signed extrinsic for the Kitties pallet.
+  Let's outline what the `TransferModal` will do. 
+  Conveniently, the Substrate Front-end Template comes with a component called `TxButton` which is a useful way to include a transfer button that interacts with a node. 
+  This component will allow us to send a transaction into our node and trigger a signed extrinsic for the Kitties pallet.
 
-The way it is built can be broken down into the following pieces:
+  The way it is built can be broken down into the following pieces:
 
     - A "transfer" button exists, which opens up a modal upon being clicked.
     - This modal, we'll call "Kitty Transfer" is a `Form` containing (1) the Kitty ID and (2) an input
     field for a receiving address.
     - It also contains a "transfer" and "cancel" button.
 
-See the screenshot for reference:
+  See the screenshot below for reference:
 
-![Kitty Transfer](/img/tutorials/kitties-workshop/kitty-transfer-shot.png)
+  ![Kitty Transfer](/img/tutorials/kitties-workshop/kitty-transfer-shot.png)
 
-1. The first thing we'll do is to extract the properties (or "props") we need using React hooks.
-   These are: `kitty`, `accountPair` and `setStatus`. Do this by pasting in the following code snippet:
+1. You'll need to extract the properties (or "props") to access your node's state using React hooks.
+   These are: `kitty`, `accountPair` and `setStatus`. 
+   Do this by pasting in the following code snippet:
 
    ```js
    const TransferModal = props => {
@@ -480,10 +433,11 @@ See the screenshot for reference:
      };
    ```
 
-We also need a `confirmAndClose` function to be passed into the `TxButton` component, being called
-when a confirmation action is triggered. This function will receive an unsubscription function from
-`TxButton`. In addition to calling this function for clean up, we will just close the modal dialog box.
-Paste the following snippet:
+  We also need a `confirmAndClose` function to be passed into the `TxButton` component, being called when a confirmation action is triggered. 
+  This function will receive an unsubscription function from `TxButton`. 
+  In addition to calling this function for clean up, we will just close the modal dialog box.
+
+1. Paste the following snippet:
 
     ```js
       const confirmAndClose = (unsub) => {
@@ -492,17 +446,16 @@ Paste the following snippet:
       };
     ```
 
-Our Kitty Card has a "transfer" button that opens up a
-modal where a user can choose an address to send their Kitty to. That modal will have:
+  Our Kitty Card has a "transfer" button that opens up a modal where a user can choose an address to send their Kitty to. 
+  That modal will have:
 
-    - a Title
-    - an read-only field for a Kitty ID
-    - an input field for an Account ID
-    - a "Cancel" button which closes the Transfer modal
-    - the `TxButton` React component to trigger the transaction
+    - a Title.
+    - an read-only field for a Kitty ID.
+    - an input field for an Account ID.
+    - a "Cancel" button which closes the Transfer modal.
+    - the `TxButton` React component to trigger the transaction.
 
-1. Paste this in to complete `TransferModal` and read the
-   comments to follow what each piece of code is doing:
+1. Paste this in to complete `TransferModal` and read the comments to follow what each piece of code is doing:
 
    ```js
    return <Modal onClose={() => setOpen(false)} onOpen={() => setOpen(true)} open={open}
@@ -536,8 +489,7 @@ modal where a user can choose an address to send their Kitty to. That modal will
    };
    ```
 
-The next part of our `KittyCards.js` component is to create the part that renders the
-`KittyAvatar.js` component and the data passed in from the `kitties` props in `Kitty.js`.
+The next part of our `KittyCards.js` component is to create the part that renders the `KittyAvatar.js` component and the data passed in from the `kitties` props in `Kitty.js`.
 
 ### Write `KittyCard` in `KittyCards.js`
 
@@ -547,62 +499,62 @@ Kitty ID, DNA, gender, owner and price.
 1. As you might have guessed, we'll use React props to pass in data to our KittyCard. Paste the
    following code snippet:
 
-```js
-// Use props
-const KittyCard = props => {
-  const { kitty, accountPair, setStatus } = props;
-  const { id = null, dna = null, owner = null, gender = null, price = null } = kitty;
-  const displayDna = dna && dna.toJSON();
-  const isSelf = accountPair.address === kitty.owner;
-```
+  ```js
+  // Use props
+  const KittyCard = props => {
+    const { kitty, accountPair, setStatus } = props;
+    const { id = null, dna = null, owner = null, gender = null, price = null } = kitty;
+    const displayDna = dna && dna.toJSON();
+    const isSelf = accountPair.address === kitty.owner;
+  ```
 
 1. Write out the contents for the `Card` component. Paste the following and read the comments to
    understand what each line is doing:
 
-```js
-return <Card>
-  { isSelf && <Label as='a' floating color='teal'>Mine</Label> }
-  {/* Render the Kitty Avatar */}
-  <KittyAvatar dna={dna.toU8a()} />
-  <Card.Content>
-    {/* Display the Kitty ID */}
-    <Card.Header style={{ fontSize: '1em', overflowWrap: 'break-word' }}>
-      ID: {id}
-    </Card.Header>
-    {/* Display the Kitty DNA */}
-    <Card.Meta style={{ fontSize: '.9em', overflowWrap: 'break-word' }}>
-      DNA: {displayDna}
-    </Card.Meta>
-    {/* Display the Kitty ID, Gender, Owner and Price */}
-    <Card.Description>
-      <p style={{ overflowWrap: 'break-word' }}>
-        Gender: {gender}
-      </p>
-      <p style={{ overflowWrap: 'break-word' }}>
-        Owner: {owner}
-      </p>
-      <p style={{ overflowWrap: 'break-word' }}>
-        Price: {price}
-      </p>
-    </Card.Description>
-  </Card.Content>
-  // ...
-```
+  ```js
+  return <Card>
+    { isSelf && <Label as='a' floating color='teal'>Mine</Label> }
+    {/* Render the Kitty Avatar */}
+    <KittyAvatar dna={dna.toU8a()} />
+    <Card.Content>
+      {/* Display the Kitty ID */}
+      <Card.Header style={{ fontSize: '1em', overflowWrap: 'break-word' }}>
+        ID: {id}
+      </Card.Header>
+      {/* Display the Kitty DNA */}
+      <Card.Meta style={{ fontSize: '.9em', overflowWrap: 'break-word' }}>
+        DNA: {displayDna}
+      </Card.Meta>
+      {/* Display the Kitty ID, Gender, Owner and Price */}
+      <Card.Description>
+        <p style={{ overflowWrap: 'break-word' }}>
+          Gender: {gender}
+        </p>
+        <p style={{ overflowWrap: 'break-word' }}>
+          Owner: {owner}
+        </p>
+        <p style={{ overflowWrap: 'break-word' }}>
+          Price: {price}
+        </p>
+      </Card.Description>
+    </Card.Content>
+    // ...
+  ```
 
-Before closing the `<Card/>` component we want to render the `TransferModal` we previously built
+1. Before closing the `<Card/>` component we want to render the `TransferModal` we previously built
 &mdash; **only if the Kitty is transferrable by its owner**. Paste this code snippet to handle this
 functionality:
 
-```js
-  {/* Render the transfer button using TransferModal */}
-  <Card.Content extra style={{ textAlign: 'center' }}>{
-    owner === accountPair.address
-      ? <TransferModal kitty={kitty} accountPair={accountPair} setStatus={setStatus}/>
-      : ''
-  }</Card.Content>
-</Card>;
-};
-```
+  ```js
+    {/* Render the transfer button using TransferModal */}
+    <Card.Content extra style={{ textAlign: 'center' }}>{
+      owner === accountPair.address
+        ? <TransferModal kitty={kitty} accountPair={accountPair} setStatus={setStatus}/>
+        : ''
+    }</Card.Content>
+  </Card>;
+  };
+  ```
 
 1. It's time to put all the pieces we've built together. We need a function to:
 
@@ -612,49 +564,49 @@ functionality:
 
    Have a look at the comments to understand the parts of this code snippet and paste it in `KittyCards.js`:
 
-```js
-const KittyCards = props => {
-  const { kitties, accountPair, setStatus } = props
+  ```js
+  const KittyCards = props => {
+    const { kitties, accountPair, setStatus } = props
 
-  {
-    /* Check the number of Kitties */
-  }
-  if (kitties.length === 0) {
+    {
+      /* Check the number of Kitties */
+    }
+    if (kitties.length === 0) {
+      return (
+        <Message info>
+          <Message.Header>
+            No Kitty found here... Create one now!&nbsp;
+            <span role="img" aria-label="point-down">
+              👇
+            </span>
+          </Message.Header>
+        </Message>
+      )
+    }
+    {
+      /* Render Kitties using Kitty Card in a grid */
+    }
     return (
-      <Message info>
-        <Message.Header>
-          No Kitty found here... Create one now!&nbsp;
-          <span role="img" aria-label="point-down">
-            👇
-          </span>
-        </Message.Header>
-      </Message>
+      <Grid columns={3}>
+        {kitties.map((kitty, i) => (
+          <Grid.Column key={`kitty-${i}`}>
+            <KittyCard
+              kitty={kitty}
+              accountPair={accountPair}
+              setStatus={setStatus}
+            />
+          </Grid.Column>
+        ))}
+      </Grid>
     )
   }
-  {
-    /* Render Kitties using Kitty Card in a grid */
-  }
-  return (
-    <Grid columns={3}>
-      {kitties.map((kitty, i) => (
-        <Grid.Column key={`kitty-${i}`}>
-          <KittyCard
-            kitty={kitty}
-            accountPair={accountPair}
-            setStatus={setStatus}
-          />
-        </Grid.Column>
-      ))}
-    </Grid>
-  )
-}
-```
+  ```
 
 1. Complete the component by adding:
 
-```js
-export default KittyCards
-```
+  ```js
+  export default KittyCards
+  ```
 
 ### Complete `Kitties.js`
 
@@ -663,33 +615,33 @@ Now that we've built all the bits for our front-end application, we can piece ev
 1. Go back to the incompleted `Kitties.js` file and paste this code snippet to render the
    `KittyCard.js` component inside a `<Grid/>`:
 
-```js
-return <Grid.Column width={16}>
-  <h1>Kitties</h1>
-  <KittyCards kitties={kitties} accountPair={accountPair} setStatus={setStatus}/>
-```
+  ```js
+  return <Grid.Column width={16}>
+    <h1>Kitties</h1>
+    <KittyCards kitties={kitties} accountPair={accountPair} setStatus={setStatus}/>
+  ```
 
 1. Now we'll use the `<Form/>` component to render our application's `TxButton` component. Paste in the following
    snippet:
 
-```js
-    <Form style={{ margin: '1em 0' }}>
-      <Form.Field style={{ textAlign: 'center' }}>
-        <TxButton
-          accountPair={accountPair} label='Create Kitty' type='SIGNED-TX' setStatus={setStatus}
-          attrs={{
-            palletRpc: 'substrateKitties',
-            callable: 'createKitty',
-            inputParams: [],
-            paramFields: []
-          }}
-        />
-      </Form.Field>
-    </Form>
-    <div style={{ overflowWrap: 'break-word' }}>{status}</div>
-  </Grid.Column>;
-}
-```
+  ```js
+      <Form style={{ margin: '1em 0' }}>
+        <Form.Field style={{ textAlign: 'center' }}>
+          <TxButton
+            accountPair={accountPair} label='Create Kitty' type='SIGNED-TX' setStatus={setStatus}
+            attrs={{
+              palletRpc: 'substrateKitties',
+              callable: 'createKitty',
+              inputParams: [],
+              paramFields: []
+            }}
+          />
+        </Form.Field>
+      </Form>
+      <div style={{ overflowWrap: 'break-word' }}>{status}</div>
+    </Grid.Column>;
+  }
+  ```
 
 ### Update App.js
 
@@ -697,26 +649,31 @@ Now all that's left to do is connect our custom components to the main applicati
 
 1. In `App.js`, import the `Kitties.js` component:
 
-```js
-import Kitties from './Kitties'
-```
+  ```js
+  import Kitties from './Kitties'
+  ```
 
 1. Finally, to render `Kitties.js`, add a new row to `<Container/>`:
 
-```js
-<Grid.Row>
-  <Kitties accountPair={accountPair} />
-</Grid.Row>
-```
+  ```js
+  <Grid.Row>
+    <Kitties accountPair={accountPair} />
+  </Grid.Row>
+  ```
 
-If you get stuck in any of the above section. You can refer back to the complete source code of:\n
+1. Now run `yarn start`, refresh your browser and you should be able to start interacting with your node.
+
+If you get stuck in any of the above section, you can refer back to the complete source code of:
 
 - [`src/kitties.js`](https://github.com/substrate-developer-hub/substrate-front-end-template/blob/tutorials%2Fkitties/src/Kitties.js)
 - [`src/kittyCards.js`](https://github.com/substrate-developer-hub/substrate-front-end-template/blob/tutorials%2Fkitties/src/KittyCards.js)
 - [`src/kittyAvatar.js`](https://github.com/substrate-developer-hub/substrate-front-end-template/blob/tutorials%2Fkitties/src/KittyAvatar.js)
 
-Congratulations! You have finished the Substrate Kitties front-end turorial! Now run `yarn start`, refresh your
-browser and you should be able to start interacting with your node.
+Congratulations! You have finished the Substrate Kitties front-end turorial! 
+We encourage you to write additional functions for other capabilities exposed by your runtime, such as "Set Price", "Buy" or "Breed".
+In [our solution](https://github.com/substrate-developer-hub/substrate-front-end-template/blob/tutorials%2Fkitties/src/KittyCards.js), we implemented the Set Price modal for you to use as an additional example.
+There's lots of ways you can extend what you've learnt here, such as creating a marketplace for different types of avatars, or recreating this front-end with your own UI components.
+
 
 ## Next steps
 

--- a/v3/tutorials/11-kitties-workshop/b-kitties-frontend/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/b-kitties-frontend/index.mdx
@@ -303,7 +303,7 @@ out in our `convertToKittyHash` function.
 const asyncFetch = async () => {
   unsub = await api.query.substrateKitties.kitties.kittyCnt(async cnt => {
     // Fetch all kitty keys
-    const entries = await api.query.substrateKitties.kitties.kitties.entries()
+    const entries = await api.query.substrateKitties.kitties.entries()
     const hashes = entries.map(convertToKittyHash)
     setKittyHashes(hashes)
   })


### PR DESCRIPTION
This PR updates several things around maintaining the Kitty tutorial, in the different repositories it touches. There's two main areas of updating: code on template branches and write-up here. 

[Front-end template](https://github.com/substrate-developer-hub/substrate-front-end-template/tree/tutorials/kitties) (code updates):
- [x] Finish "Set Price" modal as per #461 
- [x] Update dependencies: @polkadot/api  and @polkadot/types to [6.7.2](https://www.npmjs.com/package/@polkadot/api/v/6.7.2). Follow [last months PR](https://github.com/substrate-developer-hub/substrate-front-end-template/pull/206) to capture other necessary changes. (See [commits from Nov 9, 2021](https://github.com/substrate-developer-hub/substrate-front-end-template/commits/tutorials/kitties))
- [x] Remove `types.json` (See [commits from Nov 9, 2021](https://github.com/substrate-developer-hub/substrate-front-end-template/commits/tutorials/kitties))

[Node template branch](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/kitties) (code updates):
- [x] Fix pallet name to match #357. 
- [x] Remove `runtime/types.json` 
   See [commits from Nov 9th, 2021](https://github.com/substrate-developer-hub/substrate-node-template/commits/tutorials/kitties).
- [x] Update to latest monthly tag as per #511
       See [commit](https://github.com/substrate-developer-hub/substrate-node-template/commit/23b0544b491a32b90d8c888d2827dc91befe3340).


Substrate docs (write-up):
- [x] Update write-up according to pallet name changes (from `Kitties` to `SubstrateKitties`)
- [x] Update template files and write-up with [new `construct_runtime!` pallet declaration](https://github.com/paritytech/substrate/issues/8084) 
- [x] Remove `types.json` in both template code (in this repo) and write-up
- [x] Fix issues from post #482 (examples include [this](https://github.com/substrate-developer-hub/substrate-docs/commit/7a476cee905409fc7a248ecd445cdd79f77fdeb3#diff-e72209da452abb0bfa88138275b24ceb3cc44c6330199f8d2df21bbb23628310R176) and other numbering issues because of indentation changes).
- [x] Check #516 