### PR TITLE
Update link to SCALE C++ implementation

### DIFF
--- a/v3/docs/07-advanced/b-scale-codec/index.mdx
+++ b/v3/docs/07-advanced/b-scale-codec/index.mdx
@@ -198,7 +198,7 @@ that is written in Rust and maintained by Parity Technologies.
 - Rust: [`paritytech/parity-scale-codec`](https://github.com/paritytech/parity-scale-codec)
 - Python: [`polkascan/py-scale-codec`](https://github.com/polkascan/py-scale-codec)
 - Golang: [`itering/scale.go`](https://github.com/itering/scale.go)
-- C++: [`soramitsu/scale`](https://github.com/soramitsu/kagome/tree/master/core/scale)
+- C++: [`soramitsu/scale-codec-cpp`](https://github.com/soramitsu/scale-codec-cpp)
 - JavaScript: [`polkadot-js/api`](https://github.com/polkadot-js/api)
 - AssemblyScript: [`LimeChain/as-scale-codec`](https://github.com/LimeChain/as-scale-codec)
 - Haskell: [`airalab/hs-web3`](https://github.com/airalab/hs-web3/tree/master/packages/scale)


### PR DESCRIPTION
SCALE C++ implementation was recently moved to a new repo, hence the link should be updated.