### PR TITLE
Anchor not working, misses trailing "s"

### DIFF
--- a/v3/docs/01-getting-started/e-glossary/index.mdx
+++ b/v3/docs/01-getting-started/e-glossary/index.mdx
@@ -588,7 +588,7 @@ maintained by [Parity Technologies](https://www.parity.io/).
 A type of [extrinsic](#extrinsic) that can be safely gossiped between [nodes](#node) on the network
 thanks to efficient [verification](#cryptographic-primitives) through
 [signatures](/v3/concepts/extrinsics#signed-transactions) or
-[signed extensions](/v3/concepts/tx-pool#signed-extension).
+[signed extensions](/v3/concepts/tx-pool#signed-extensions).
 
 ## Transaction Era
 

--- a/v3/docs/02-concepts/b-extrinsics/index.mdx
+++ b/v3/docs/02-concepts/b-extrinsics/index.mdx
@@ -64,7 +64,7 @@ Since the transaction is not signed, there is nobody to pay a fee. Because of th
 queue lacks economic logic to prevent spam. Unsigned transactions also lack a nonce, making replay
 protection difficult. A few transactions warrant using the unsigned variant, but they will require
 some form of spam prevention based on a custom implementation of
-[signed extension](/v3/concepts/tx-pool#signed-extension), which can exist on unsigned transactions.
+[signed extension](/v3/concepts/tx-pool#signed-extensions), which can exist on unsigned transactions.
 
 An example of unsigned transactions in Substrate is the [I'm Online](/v3/runtime/frame#im-online)
 heartbeat transaction sent by authorities. The transaction includes a signature from a Session key,

--- a/v3/docs/03-runtime/h-weights-and-fees/index.mdx
+++ b/v3/docs/03-runtime/h-weights-and-fees/index.mdx
@@ -402,7 +402,7 @@ impl<T: Get<Perquintill>> Convert<Fixed128, Fixed128> for TargetedFeeAdjustment<
 
 ## Next steps
 
-The entire logic of fees is encapsulated in `pallet-transaction-payment` via a [`SignedExtension`](/v3/concepts/tx-pool#signed-extension).
+The entire logic of fees is encapsulated in `pallet-transaction-payment` via a [`SignedExtension`](/v3/concepts/tx-pool#signed-extensions).
 While this pallet provides a high degree of flexibility, a user can opt to build their custom
 payment module drawing inspiration from Transaction Payment.
 


### PR DESCRIPTION
Currently does not jump to wanted section because the anchor hash misses a traling `s`