### PR TITLE
[docs] typo

### DIFF
--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -19,7 +19,7 @@ This tutorial illustrates how to create a custom proof-of-existence (PoE) servic
 blockchain development framework and the [FRAME](/v3/runtime/frame) library.
 
 Proof of existence is an approach to validating the authenticity and ownership of a digital object by using the object information stored on the blockchain.
-Because the blockchain associates a timestamp and signature with the object, the blockchain record can be used to verify—to serve as proof—that a particular object existed at a specific date and time. It can also verify who the owner of record was at that date and time.
+Because the blockchain associates a timestamp and signature with the object, the blockchain record can be used to verify—to serve as proof—that a particular object existed at a specific date and time. It can also verify who the owner of a record was at that date and time.
 
 ## Digital objects and hashes
 


### PR DESCRIPTION
there should be an `a`