### PR TITLE
Update permissioned-network template version to `monthly-2021-11`

### DIFF
--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -112,12 +112,12 @@ the right CLI flag as offchain worker is disabled by default for non-authority n
 ### Build the Node Template
 
 If you already have Node Template cloned, you can just create a
-**check out of the `monthly-2021-11-1` tag** from the base template,
+**check out of the `monthly-2021-11` tag** from the base template,
 otherwise, clone this branch of the project:
 
 ```bash
 # Fresh clone, if needed:
-git clone -b monthly-2021-11-1 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+git clone -b monthly-2021-11 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
 # From the working directory, create a new branch and check it out
 cd substrate-node-template
 git branch perm-network

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -112,12 +112,12 @@ the right CLI flag as offchain worker is disabled by default for non-authority n
 ### Build the Node Template
 
 If you already have Node Template cloned, you can just create a
-**check out of the `monthly-2021-11` tag** from the base template,
+**check out of the `monthly-2021-11-1` tag** from the base template,
 otherwise, clone this branch of the project:
 
 ```bash
 # Fresh clone, if needed:
-git clone -b monthly-2021-11 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+git clone -b monthly-2021-11-1 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
 # From the working directory, create a new branch and check it out
 cd substrate-node-template
 git branch perm-network

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -112,12 +112,12 @@ the right CLI flag as offchain worker is disabled by default for non-authority n
 ### Build the Node Template
 
 If you already have Node Template cloned, you can just create a
-**check out of the v3.0.0 branch** from the base template,
+**check out of the `monthly-2021-11` tag** from the base template,
 otherwise, clone this branch of the project:
 
 ```bash
 # Fresh clone, if needed:
-git clone -b v3.0.0 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+git clone -b monthly-2021-11 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
 # From the working directory, create a new branch and check it out
 cd substrate-node-template
 git branch perm-network
@@ -273,7 +273,7 @@ fn testnet_genesis(
 					endowed_accounts[1].clone()
 				),
     		],
-   		}),
+        },
 
     /* --snip-- */
 


### PR DESCRIPTION
Template version `v3.0.0` can no longer build due to dependency issues. It should be bumped to the latest version.
I use the `monthly-2021-11` node template in the tutorial and it works well in general. 

But there is still another problem, `custom type mapping` can be no longer changed in polkadot.js apps as the developer page is gone. And the whole part that custom type mapping is no longer needed. I finished the rest of the tutorial even skipping that part. But I'm not sure if it should be deleted or have a further explanation. So I leave it with an issue (#583).

Also, fix a typo in the code snippet.