### PR TITLE
Bugfix: remove #[pallet::generate_storage_info]

### DIFF
--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -137,7 +137,6 @@ Therefore, the first step is to remove some files and content from the files in 
    #[pallet::error]   // <-- Step 4. code block will replace this.
    #[pallet::pallet]
    #[pallet::generate_store(pub(super) trait Store)]
-   #[pallet::generate_storage_info]
    pub struct Pallet<T>(_);
 
    #[pallet::storage] // <-- Step 5. code block will replace this.


### PR DESCRIPTION
The code created by following the tutorial does not compile:

```
 cargo check -p node-template-runtime   Compiling node-template-runtime v3.0.0-monthly-2021-10 ($HOME/workspace/blockchain/substrate-node-template/runtime)
    Checking pallet-template v3.0.0-monthly-2021-10 ($HOME/workspace/blockchain/substrate-node-template/pallets/template)
error[E0277]: the trait bound `Vec<u8>: MaxEncodedLen` is not satisfied
  --> pallets/template/src/lib.rs:43:11
   |
43 | #[pallet::generate_storage_info]
   |           ^^^^^^^^^^^^^^^^^^^^^ the trait `MaxEncodedLen` is not implemented for `Vec<u8>`
   |
   = note: required because of the requirements on the impl of `StorageInfoTrait` for `frame_support::pallet_prelude::StorageMap<_GeneratedPrefixForStorageProofs<T>, frame_support::Blake2_128Concat, Vec<u8>, (<T as frame_system::Config>::AccountId, <T as frame_system::Config>::BlockNumber), frame_support::pallet_prelude::ValueQuery>`
note: required by `storage_info`
  --> $HOME/.cargo/git/checkouts/substrate-7e08433d4c370a21/bf9683e/frame/support/src/traits/storage.rs:71:2
   |
71 |     fn storage_info() -> Vec<StorageInfo>;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0277`.
error: could not compile `pallet-template` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Remove `#[pallet::generate_storage_info]` preceding `pub struct Pallet<T>(_);`