### PR TITLE
Add Troubleshooting and FAQ section 

### DIFF
--- a/src/components/DevNavMenu.tsx
+++ b/src/components/DevNavMenu.tsx
@@ -265,6 +265,15 @@ const DevNavMenu = {
         ],
       },
       {
+        name: `Troubleshooting and FAQ`,
+        items: [
+          {
+            title: `Common issues`,
+            link: '/v3/troubleshooting',
+          },
+        ],
+      }, 
+      {
         name: `${intl.formatMessage({ id: 'docs-menu-contribute' })}`,
         items: [
           {

--- a/v3/docs/08-FAQ-and-troubleshooting/index.mdx
+++ b/v3/docs/08-FAQ-and-troubleshooting/index.mdx
@@ -1,0 +1,56 @@
+---
+title: Troubleshooting and FAQ
+slug: /v3/troubleshooting
+version: '3.0'
+section: docs
+category: 
+keywords:
+---
+
+Developers building with Substrate may come into issues with mismatched versions or breaking changes that result in incompatibility issues.
+This page is a living document of how to work around these types of common issues.
+
+## Using PolkadotJS Apps with a Substrate node that does not yet use the `scale-info` pallet 
+
+*Issue*: The hosted PolkadotJS apps UI no longer requires adding custom metadata.
+Instead, it expects the Substrate node to use `scale_info::TypeInfo` on all its custom enums and structs.
+Chains that have not been updated to include the `scale-info` crate will not be able to pass in custom types to the latest version of PolkadotJS Apps.
+
+*Solution*: Use an older version of PolkadotJS Apps.
+
+The last release that includes the custom types in the UI is `v0.96.1`, [available here](https://github.com/polkadot-js/apps/releases/tag/v0.96.1).
+
+1. Clone PolkadotJS apps v0.96.1. 
+
+    ```bash
+    git clone --depth=1 git@github.com:polkadot-js/apps.git --branch v0.96.1
+    ```
+
+1. Install and start the UI locally.
+    
+    Ensure that you have a recent LTS version of Node.js and Yarn. f
+    For development purposes Node >=10.13.0 is recommended and Yarn >=1.10.1 is required.
+
+    ```bash
+    yarn install 
+    yarn start
+    ```
+
+1. Access the UI at http://localhost:3000.
+ 
+1. Go to **Settings -> Developer** page and paste in your chain's custom types. 
+
+    For example, if you are doing the [permissioned network tutorial](/tutorials/v3/permissioned-network/) with an older Substrate chain, you would add:
+
+    ```json
+    {
+    "PeerId": "(Vec<u8>)"
+    }
+    ```
+
+    If you don't do this, you will get extrinsic errors of the form: `Verification Error: Execution(ApiError(Could not convert parameter 'tx' between node and runtime)`.
+    See more details about the error [here](https://polkadot.js.org/docs/api/FAQ#the-node-returns-a-could-not-convert-error-on-send).
+
+Note that it is highly recommended to include `scale-info` in your node.
+Using it is a very powerful and useful feature which was introduced [in this PR](https://github.com/paritytech/substrate/pull/8615).
+

--- a/v3/docs/08-FAQ-and-troubleshooting/index.mdx
+++ b/v3/docs/08-FAQ-and-troubleshooting/index.mdx
@@ -54,3 +54,21 @@ The last release that includes the custom types in the UI is `v0.96.1`, [availab
 Note that it is highly recommended to include `scale-info` in your node.
 Using it is a very powerful and useful feature which was introduced [in this PR](https://github.com/paritytech/substrate/pull/8615).
 
+## Persisting data when running a node in `--dev` mode
+
+*Issue*: When running a chain in developer mode, the `--tmp` flag is implied by default.
+The `--tmp` flag implies that a temporary directory is created and used as a basepath to store a database, keystore and node key. 
+Once the chain is stopped, this directory is deleted.
+Now that the `--tmp` flag is implied by default, some developers may want to have their chain's database persist between starting and stopping their chain.
+
+*Solution*: Provide an explicit base path.
+1. Name your base path, for example `tmp/base-path`.
+
+1. Run the node template and specify your base path.
+
+    ```bash
+    ./target/release/node-template --dev  --base-path /tmp/base-path
+    ```
+
+With this, you can stop your chain and when you restart it, it will resume on the last finalized block.
+See [the original PR](https://github.com/paritytech/substrate/pull/9938) for more details on this change. 

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -599,7 +599,7 @@ permissioned network. You can also play with other dispatchable calls like
 > This powerful and very useful feature was introduced [in this PR](https://github.com/paritytech/substrate/pull/8615).
 > We highly recommend including this in your node!
 
-The hosted apps UI is _not compatible_ with custom metadata any longer.
+The hosted apps UI is not compatible with custom metadata any longer.
 To use custom type mappings you manually specify, you need to clone and run a compatible version yourself.
 
 The last release including the custom types in the UI is [`v0.96.1` available here](https://github.com/polkadot-js/apps/releases/tag/v0.96.1)

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -463,6 +463,9 @@ stored in the `nodeAuthorization` pallet, `wellKnownNodes` storage. You should b
 able to see the peer ids of Alice and Bob's nodes, prefixed with `0x` to show its
 bytes in hex format.
 
+> NOTE: if you are using an older node that **does not include the `scale-info` pallet, you will need to use an **older version of the UI that you build and run yourself, as custom type mappings that you needed before are no longer supported (this is a very good thing!)
+> For how to use an older apps UI, see the [instructions at the end of this page](#apps-ui-use-without-scale-info).
+
 We can also check the owner of one node by querying the storage `owners` with the
 peer id of the node as input, you should get the account address of the owner.
 
@@ -589,6 +592,47 @@ Restart Dave's node in case it's not connecting with Charlie right away.
 You are at the end of this tutorial and are already learned about how to build a
 permissioned network. You can also play with other dispatchable calls like
 `remove_well_known_node`, `remove_connections`.
+
+## Apps UI use without `scale-info`
+
+> The instructions bellow _only_ apply to nodes that do not use the `scale-info` pallet that all modern Substrate nodes do.
+> This powerful and very useful feature was introduced [in this PR](https://github.com/paritytech/substrate/pull/8615).
+> We highly recommend including this in your node!
+
+The hosted apps UI is _not compatible_ with custom metadata any longer.
+To use custom type mappings you manually specify, you need to clone and run a compatible version yourself.
+
+The last release including the custom types in the UI is [`v0.96.1` available here](https://github.com/polkadot-js/apps/releases/tag/v0.96.1)
+
+```bash
+# choose ONLY one clone method:
+# ssh (better!)
+git clone --depth=1 git@github.com:polkadot-js/apps.git --branch v0.96.1
+# https (if needed)
+git clone --depth=1 https://github.com/polkadot-js/apps.git --branch v0.96.1
+
+# Install, build, serve (https://github.com/polkadot-js/apps#development)
+# - Ensure that you have a recent LTS version of Node.js, for development purposes Node >=10.13.0 is recommended.
+# - Ensure that you have a recent version of Yarn, for development purposes Yarn >=1.10.1 is required.
+yarn
+yarn start
+# - Access the UI via http://localhost:3000
+```
+
+We need to add an extra setting to tell the frontend the type of the `PeerId` used in node-authorization pallet.
+Note: the format of `PeerId` here is a wrapper on bs58 decoded peer id in bytes.
+Go to the **Settings Developer** [page in apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/settings/developer), add following [custom type mapping](https://polkadot.js.org/docs/api/start/types.extend)
+information:
+
+```json
+// add this as is, or with other required types you have set already:
+{
+  "PeerId": "(Vec<u8>)"
+}
+```
+
+> If you don't do this, you will get extrinsic errors of the form: `Verification Error: Execution(ApiError(Could not convert parameter 'tx' between node and runtime)`.
+> More details [here](https://polkadot.js.org/docs/api/FAQ#the-node-returns-a-could-not-convert-error-on-send).
 
 ## Next steps
 

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -463,9 +463,6 @@ stored in the `nodeAuthorization` pallet, `wellKnownNodes` storage. You should b
 able to see the peer ids of Alice and Bob's nodes, prefixed with `0x` to show its
 bytes in hex format.
 
-> NOTE: if you are using an older node that **does not include the `scale-info` pallet, you will need to use an **older version of the UI that you build and run yourself, as custom type mappings that you needed before are no longer supported (this is a very good thing!)
-> For how to use an older apps UI, see the [instructions at the end of this page](#apps-ui-use-without-scale-info).
-
 We can also check the owner of one node by querying the storage `owners` with the
 peer id of the node as input, you should get the account address of the owner.
 
@@ -592,47 +589,6 @@ Restart Dave's node in case it's not connecting with Charlie right away.
 You are at the end of this tutorial and are already learned about how to build a
 permissioned network. You can also play with other dispatchable calls like
 `remove_well_known_node`, `remove_connections`.
-
-## Apps UI use without `scale-info`
-
-> The instructions bellow _only_ apply to nodes that do not use the `scale-info` pallet that all modern Substrate nodes do.
-> This powerful and very useful feature was introduced [in this PR](https://github.com/paritytech/substrate/pull/8615).
-> We highly recommend including this in your node!
-
-The hosted apps UI is _not compatible_ with custom metadata any longer.
-To use custom type mappings you manually specify, you need to clone and run a compatible version yourself.
-
-The last release including the custom types in the UI is [`v0.96.1` available here](https://github.com/polkadot-js/apps/releases/tag/v0.96.1)
-
-```bash
-# choose ONLY one clone method:
-# ssh (better!)
-git clone --depth=1 git@github.com:polkadot-js/apps.git --branch v0.96.1
-# https (if needed)
-git clone --depth=1 https://github.com/polkadot-js/apps.git --branch v0.96.1
-
-# Install, build, serve (https://github.com/polkadot-js/apps#development)
-# - Ensure that you have a recent LTS version of Node.js, for development purposes Node >=10.13.0 is recommended.
-# - Ensure that you have a recent version of Yarn, for development purposes Yarn >=1.10.1 is required.
-yarn
-yarn start
-# - Access the UI via http://localhost:3000
-```
-
-We need to add an extra setting to tell the frontend the type of the `PeerId` used in node-authorization pallet.
-Note: the format of `PeerId` here is a wrapper on bs58 decoded peer id in bytes.
-Go to the **Settings Developer** [page in apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/settings/developer), add following [custom type mapping](https://polkadot.js.org/docs/api/start/types.extend)
-information:
-
-```json
-// add this as is, or with other required types you have set already:
-{
-  "PeerId": "(Vec<u8>)"
-}
-```
-
-> If you don't do this, you will get extrinsic errors of the form: `Verification Error: Execution(ApiError(Could not convert parameter 'tx' between node and runtime)`.
-> More details [here](https://polkadot.js.org/docs/api/FAQ#the-node-returns-a-could-not-convert-error-on-send).
 
 ## Next steps
 

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -458,31 +458,7 @@ finalized in bother terminal logs. Now let's use the
 and check the well known nodes of our blockchain. Don't forget to switch to one of
 our local nodes running: `127.0.0.1:9944` or `127.0.0.1:9945`.
 
-Firstly, we need to add an extra setting to tell the frontend the type of the `PeerId` used
-in node-authorization pallet. Note: the format of `PeerId` here is a wrapper on bs58 decoded
-peer id in bytes. Go to the **Settings Developer**
-[page in apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/settings/developer)
-, add following [custom type mapping](https://polkadot.js.org/docs/api/start/types.extend)
-information:
-
-```json
-// add this as is, or with other required types you have set already:
-{
-  "PeerId": "(Vec<u8>)"
-}
-```
-
-<br />
-<Message
-  type={`red`}
-  title={`Warning`}
-  text="If you don't do this, you will get extrinsic errors of the form:
-    `Verification Error: Execution(ApiError(Could not convert parameter 'tx' between node and runtime)`. 
-    More details [here](https://polkadot.js.org/docs/api/FAQ#the-node-returns-a-could-not-convert-error-on-send).
-    "
-/>
-
-Then, let's go to **Developer** page, **Chain State sub-tab**, and check the data
+First, let's go to **Developer** page, **Chain State sub-tab**, and check the data
 stored in the `nodeAuthorization` pallet, `wellKnownNodes` storage. You should be
 able to see the peer ids of Alice and Bob's nodes, prefixed with `0x` to show its
 bytes in hex format.

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -458,7 +458,31 @@ finalized in bother terminal logs. Now let's use the
 and check the well known nodes of our blockchain. Don't forget to switch to one of
 our local nodes running: `127.0.0.1:9944` or `127.0.0.1:9945`.
 
-First, let's go to **Developer** page, **Chain State sub-tab**, and check the data
+Firstly, we need to add an extra setting to tell the frontend the type of the `PeerId` used
+in node-authorization pallet. Note: the format of `PeerId` here is a wrapper on bs58 decoded
+peer id in bytes. Go to the **Settings Developer**
+[page in apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/settings/developer)
+, add following [custom type mapping](https://polkadot.js.org/docs/api/start/types.extend)
+information:
+
+```json
+// add this as is, or with other required types you have set already:
+{
+  "PeerId": "(Vec<u8>)"
+}
+```
+
+<br />
+<Message
+  type={`red`}
+  title={`Warning`}
+  text="If you don't do this, you will get extrinsic errors of the form:
+    `Verification Error: Execution(ApiError(Could not convert parameter 'tx' between node and runtime)`. 
+    More details [here](https://polkadot.js.org/docs/api/FAQ#the-node-returns-a-could-not-convert-error-on-send).
+    "
+/>
+
+Then, let's go to **Developer** page, **Chain State sub-tab**, and check the data
 stored in the `nodeAuthorization` pallet, `wellKnownNodes` storage. You should be
 able to see the peer ids of Alice and Bob's nodes, prefixed with `0x` to show its
 bytes in hex format.

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -599,7 +599,7 @@ permissioned network. You can also play with other dispatchable calls like
 > This powerful and very useful feature was introduced [in this PR](https://github.com/paritytech/substrate/pull/8615).
 > We highly recommend including this in your node!
 
-The hosted apps UI is not compatible with custom metadata any longer.
+The hosted apps UI is _not compatible_ with custom metadata any longer.
 To use custom type mappings you manually specify, you need to clone and run a compatible version yourself.
 
 The last release including the custom types in the UI is [`v0.96.1` available here](https://github.com/polkadot-js/apps/releases/tag/v0.96.1)


### PR DESCRIPTION
This PR was originally called "Use Apps UI use without `scale-info`" .  We agreed to alter the PR and create a section for the information it was originally putting forward.

Originally it: 
- [x] Closes #583 
- [x] Adds instructions that could be a stand-alone HTG on Apps UI use without `scale-info` (in followup PR) 

With @sacha-l 's recent updates, it now:
- Adds a section in our docs called "Troubleshooting and FAQ" 
- Add a page that contains information on: how to use PolkadotJS apps with a Substrate runtime that doesn't have the new `scale-info` pallet and how to use `--dev` without the (now) default `--tmp`.

This directly addresses #631 . Going forward, this section can be used by the support team and slowly will morph into the "FAQ dump" page idea the docs team has been pondering about. 