### PR TITLE
Kitties tutorial code fixes

### DIFF
--- a/static/assets/tutorials/kitties-tutorial/01-basic-setup.rs
+++ b/static/assets/tutorials/kitties-tutorial/01-basic-setup.rs
@@ -17,7 +17,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
-    #[pallet::generate_storage_info]
     pub struct Pallet<T>(_);
 
     /// Configure the pallet by specifying the parameters and types it depends on.

--- a/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
+++ b/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
@@ -25,7 +25,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
-    #[pallet::generate_storage_info]
     pub struct Pallet<T>(_);
 
 	/// Configure the pallet by specifying the parameters and types it depends on.

--- a/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
+++ b/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
@@ -39,16 +39,8 @@ pub mod pallet {
 		Female,
 	}
 
-	// Implementation to handle Gender type in Kitty struct.
-	impl Default for Gender {
-		fn default() -> Self {
-			Gender::Male
-		}
-	}
-
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
-    #[pallet::generate_storage_info]
     pub struct Pallet<T>(_);
 
 	/// Configure the pallet by specifying the parameters and types it depends on.

--- a/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
+++ b/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
@@ -45,7 +45,6 @@ pub mod pallet {
 
   #[pallet::pallet]
   #[pallet::generate_store(pub(super) trait Store)]
-  #[pallet::generate_storage_info]
   pub struct Pallet<T>(_);
 
   // Configure the pallet by specifying the parameters and types on which it depends.
@@ -88,18 +87,19 @@ pub mod pallet {
     NotEnoughBalance,
   }
 
-  #[pallet::event]
-  #[pallet::generate_deposit(pub(super) fn deposit_event)]
-  pub enum Event<T: Config> {
-    /// A new Kitty was sucessfully created. \[sender, kitty_id\]
-    Created(T::AccountId, T::Hash),
-    /// Kitty price was sucessfully set. \[sender, kitty_id, new_price\]
-    PriceSet(T::AccountId, T::Hash, Option<BalanceOf<T>>),
-    /// A Kitty was sucessfully transferred. \[from, to, kitty_id\]
-    Transferred(T::AccountId, T::AccountId, T::Hash),
-    /// A Kitty was sucessfully bought. \[buyer, seller, kitty_id, bid_price\]
-    Bought(T::AccountId, T::AccountId, T::Hash, BalanceOf<T>),
-  }
+	// Events.
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A new Kitty was successfully created. \[sender, kitty_id\]
+		Created(T::AccountId, T::Hash),
+		/// Kitty price was successfully set. \[sender, kitty_id, new_price\]
+		PriceSet(T::AccountId, T::Hash, Option<BalanceOf<T>>),
+		/// A Kitty was successfully transferred. \[from, to, kitty_id\]
+		Transferred(T::AccountId, T::AccountId, T::Hash),
+		/// A Kitty was successfully bought. \[buyer, seller, kitty_id, bid_price\]
+		Bought(T::AccountId, T::AccountId, T::Hash, BalanceOf<T>),
+	}
 
   // Storage items.
 

--- a/static/assets/tutorials/kitties-tutorial/05-completed.rs
+++ b/static/assets/tutorials/kitties-tutorial/05-completed.rs
@@ -2,9 +2,6 @@
 
 pub use pallet::*;
 
-mod mock;
-mod tests;
-
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::pallet_prelude::*;
@@ -27,13 +24,14 @@ pub mod pallet {
 	// Struct for holding Kitty information.
 	#[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 	#[scale_info(skip_type_params(T))]
+	pub struct Kitty<T: Config> {
 		pub dna: [u8; 16],   // Using 16 bytes to represent a kitty DNA
 		pub price: Option<BalanceOf<T>>,
 		pub gender: Gender,
 		pub owner: AccountOf<T>,
 	}
 
-	// Set Gender type in Kitty struct.
+	// Enum declaration for Gender.
 	#[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 	#[scale_info(skip_type_params(T))]
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -44,10 +42,9 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
-    #[pallet::generate_storage_info]
     pub struct Pallet<T>(_);
 
-	// Configure the pallet by specifying the parameters and types on which it depends.
+	/// Configure the pallet by specifying the parameters and types it depends on.
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
@@ -67,7 +64,7 @@ pub mod pallet {
 	// Errors.
 	#[pallet::error]
 	pub enum Error<T> {
-		/// Handles arithemtic overflow when incrementing the Kitty counter.
+		/// Handles arithmetic overflow when incrementing the Kitty counter.
 		KittyCntOverflow,
 		/// An account cannot own more Kitties than `MaxKittyCount`.
 		ExceedMaxKittyOwned,
@@ -87,16 +84,17 @@ pub mod pallet {
 		NotEnoughBalance,
 	}
 
+	// Events.
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// A new Kitty was sucessfully created. \[sender, kitty_id\]
+		/// A new Kitty was successfully created. \[sender, kitty_id\]
 		Created(T::AccountId, T::Hash),
-		/// Kitty price was sucessfully set. \[sender, kitty_id, new_price\]
+		/// Kitty price was successfully set. \[sender, kitty_id, new_price\]
 		PriceSet(T::AccountId, T::Hash, Option<BalanceOf<T>>),
-		/// A Kitty was sucessfully transferred. \[from, to, kitty_id\]
+		/// A Kitty was successfully transferred. \[from, to, kitty_id\]
 		Transferred(T::AccountId, T::AccountId, T::Hash),
-		/// A Kitty was sucessfully bought. \[buyer, seller, kitty_id, bid_price\]
+		/// A Kitty was successfully bought. \[buyer, seller, kitty_id, bid_price\]
 		Bought(T::AccountId, T::AccountId, T::Hash, BalanceOf<T>),
 	}
 

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -361,7 +361,6 @@ pub mod pallet {
 
   #[pallet::pallet]
   #[pallet::generate_store(pub(super) trait Store)]
-  #[pallet::generate_storage_info]
   pub struct Pallet<T>(_);
 
 	/// Configure the pallet by specifying the parameters and types it depends on.
@@ -428,6 +427,14 @@ pub mod pallet {
 		// TODO Part IV: transfer_kitty_to
 	}
 }
+```
+
+Along with this code, we'll need to import `serde`. 
+Add this to your pallet's Cargo.toml file:
+
+```toml
+[dependencies.serde]
+version =  '1.0.129'
 ```
 
 ### Scaffold Kitty struct


### PR DESCRIPTION
Tested on latest node template `monthly-2021-11-1`.
- Fixes template code and adds instruction to use `serde` as a dependency. 
- Removes `#[pallet::generate_storage_info]` as not necessary for tutorial.
- Slight edits to template code to match style of previous ones each builds on.
