### PR TITLE
Update tutorials to latest monthly tag

### DIFF
--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -185,7 +185,7 @@ To compile the Substrate Node Template:
 1. Clone the node template repository using the version `latest` branch by running the following command:
 
    ```
-   git clone https://github.com/substrate-developer-hub/substrate-node-template
+   git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
 1. Change to the root of the node template directory by running the following command:

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -270,7 +270,7 @@ To start the local Substrate node:
    ```
 
    The `node-template` command-line options specify how you want the running node to operate.
-   In this case, the `--dev` option specifies that the node is run as a developer node chain specification.
+   In this case, the `--dev` option specifies that the node runs in developer mode using the predefined `development` chain specification.
    By default, this also implies that the node will delete all active data—such as keys, blockchain database, and networking information when you stop the node by pressing Control-c.
    This ensures you have a clean working state any time you stop and restart the node.
 

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -236,7 +236,7 @@ To install the Front-end Template:
 1. Clone the Front-end Template repository by running the following command:
 
    ```
-   git clone https://github.com/substrate-developer-hub/substrate-front-end-template
+   git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-front-end-template
    ```
 
 1. Change to the root of the front-end template directory by running the following command:

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -185,7 +185,7 @@ To compile the Substrate Node Template:
 1. Clone the node template repository using the version `latest` branch by running the following command:
 
    ```
-   git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+   git clone https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
 1. Change to the root of the node template directory by running the following command:
@@ -236,7 +236,7 @@ To install the Front-end Template:
 1. Clone the Front-end Template repository by running the following command:
 
    ```
-   git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-front-end-template
+   git clone https://github.com/substrate-developer-hub/substrate-front-end-template
    ```
 
 1. Change to the root of the front-end template directory by running the following command:
@@ -266,43 +266,38 @@ To start the local Substrate node:
 1. Start the node in development mode by running the following command:
 
    ```
-   ./target/release/node-template --dev --tmp
+   ./target/release/node-template --dev
    ```
 
    The `node-template` command-line options specify how you want the running node to operate.
-   In this case, the options specify the following:
-
-   - The `--dev` option specifies that the node is run as a developer node chain specification.
-
-   - The `--tmp` option specifies that the node will delete all active data—such as keys,
-     blockchain database, and networking information when you stop the node by pressing Control-c.
-     You can use `--tmp` option to ensure you have a clean working state any time you stop and
-     restart the node.
+   In this case, the `--dev` option specifies that the node is run as a developer node chain specification.
+   By default, this also implies that the node will delete all active data—such as keys, blockchain database, and networking information when you stop the node by pressing Control-c.
+   This ensures you have a clean working state any time you stop and restart the node.
 
 1. Verify your node is up and running successfully by reviewing the output displayed in the terminal.
 
    The terminal should display output similar to this:
 
    ```
-   2021-03-16 10:56:51  Running in --dev mode, RPC CORS has been disabled.
-   2021-03-16 10:56:51  Substrate Node
-   2021-03-16 10:56:51  ✌️  version 3.0.0-8370ddd-x86_64-linux-gnu
-   2021-03-16 10:56:51  ❤️  by Substrate DevHub <https://github.com/substrate-developer-hub>, 2017-2021
-   2021-03-16 10:56:51  📋 Chain specification: Development
-   2021-03-16 10:56:51  🏷 Node name: few-size-5380
-   2021-03-16 10:56:51  👤 Role: AUTHORITY
-   2021-03-16 10:56:51  💾 Database: RocksDb at /tmp/substrateP1jD7H/chains/dev/db
-   2021-03-16 10:56:51  ⛓  Native runtime: node-template-100 (node-template-1.tx1.au1)
-   2021-03-16 10:56:51  🔨 Initializing Genesis block/state (state: 0x17df…04a0, header-hash: 0xc43b…ed16)
-   2021-03-16 10:56:51  👴 Loading GRANDPA authority set from genesis on what appears to be first startup.
-   2021-03-16 10:56:51  ⏱  Loaded block-time = 6000 milliseconds from genesis on first-launch
-   2021-03-16 10:56:51  Using default protocol ID "sup" because none is configured in the chain specs
-   2021-03-16 10:56:51  🏷 Local node identity is: 12D3KooWQdU84EJCqDr4aqfhb7dxXU2fzd6i2Rn1XdNtsiM5jvEC
-   2021-03-16 10:56:51  📦 Highest known block at #0
+   2021-11-24 15:36:35 Running in --dev mode, RPC CORS has been disabled.    
+   2021-11-24 15:36:35 Substrate Node    
+   2021-11-24 15:36:35 ✌️  version 4.0.0-dev-82b7c2c-aarch64-macos    
+   2021-11-24 15:36:35 ❤️  by Substrate DevHub <https://github.com/substrate-developer-hub>, 2017-2021    
+   2021-11-24 15:36:35 📋 Chain specification: Development    
+   2021-11-24 15:36:35 🏷 Node name: six-wash-9274    
+   2021-11-24 15:36:35 👤 Role: AUTHORITY    
+   2021-11-24 15:36:35 💾 Database: RocksDb at /tmp/substrateP1jD7H/chains/dev/db
+   2021-11-24 15:36:35 ⛓  Native runtime: node-template-100 (node-template-1.tx1.au1)    
+   2021-11-24 15:36:35 🔨 Initializing Genesis block/state (state: 0xa59b…5331, header-hash: 0xc5d2…37f3)    
+   2021-11-24 15:36:35 👴 Loading GRANDPA authority set from genesis on what appears to be first startup.    
+   2021-11-24 15:36:35 ⏱  Loaded block-time = 6s from block 0xc5d2fdad35e14684753f087c1a20f022274e154d39add4f7efe34e95476a37f3    
+   2021-11-24 15:36:35 Using default protocol ID "sup" because none is configured in the chain specs    
+   2021-11-24 15:36:35 🏷 Local node identity is: 12D3KooWG5niQF5bjsFao3D8DZRpUUB6uWZC2pK8hCDZ94zsr8Sc    
+   2021-11-24 15:36:35 📦 Highest known block at #0  
    ...
    ...
    ...
-   2021-03-16 10:56:56  💤 Idle (0 peers), best: #2 (0x05bd…de3f), finalized #0 (0xc43b…ed16), ⬇ 0 ⬆ 0
+   2021-11-24 15:36:40 💤 Idle (0 peers), best: #1 (0xd2b5…d03f), finalized #0 (0xc5d2…37f3), ⬇ 0 ⬆ 0    
    ```
 
    If the number after `finalized` is increasing, your blockchain is producing new blocks and reaching consensus about the state they describe.
@@ -385,7 +380,7 @@ To transfer funds to an account:
 
 After a successful transfer, you can continue to explore the front-end template components or
 stop the local Substrate node the state changes you made.
-With `--tmp` flag specified when running the Node Template, stopping the local node stops the
+With `--dev` flag specified when running the Node Template, stopping the local node stops the
 blockchain and purge all persistent block data that goes with it so you can start with a clean new
 state next time you start again.
 

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -271,8 +271,8 @@ To start the local Substrate node:
 
    The `node-template` command-line options specify how you want the running node to operate.
    In this case, the `--dev` option specifies that the node runs in developer mode using the predefined `development` chain specification.
-   By default, this also implies that the node will delete all active data—such as keys, blockchain database, and networking information when you stop the node by pressing Control-c.
-   This ensures you have a clean working state any time you stop and restart the node.
+   By default, this option also deletes all active data—such as keys, the blockchain database, and networking information when you stop the node by pressing Control-c.
+   Using the `--dev` option ensures that you have a clean working state any time you stop and restart the node.
 
 1. Verify your node is up and running successfully by reviewing the output displayed in the terminal.
 
@@ -380,9 +380,7 @@ To transfer funds to an account:
 
 After a successful transfer, you can continue to explore the front-end template components or
 stop the local Substrate node the state changes you made.
-With `--dev` flag specified when running the Node Template, stopping the local node stops the
-blockchain and purge all persistent block data that goes with it so you can start with a clean new
-state next time you start again.
+Because you specified the `--dev` option when you started the node, stopping the local node stops the blockchain and purges all persistent block data so that you can start with a clean state next time you start the node.
 
 To stop the local Substrate node:
 

--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -184,19 +184,21 @@ To compile the Substrate Node Template:
 
 1. Clone the node template repository using the version `latest` branch by running the following command:
 
-   ```
-   git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+   ```bash
+   git clone https://github.com/substrate-developer-hub/substrate-node-template
+   # We want to use the `latest` tag throughout all of this tutorial
+   git checkout latest
    ```
 
 1. Change to the root of the node template directory by running the following command:
 
-   ```
+   ```bash
    cd substrate-node-template
    ```
 
 1. Compile the node template by running the following command:
 
-   ```
+   ```bash
    cargo build --release
    ```
 
@@ -213,7 +215,7 @@ To install the Front-end Template:
 
 1. Check whether `node` is installed on your local computer by running the following command:
 
-   ```
+   ```bash
    node --version
    ```
 
@@ -223,31 +225,33 @@ To install the Front-end Template:
 
 1. Check whether `yarn` is installed on your local computer by running the following command:
 
-   ```
+   ```bash
    yarn --version
    ```
 
    If the command doesn’t return a version number, download and install `yarn` by running the following command:
 
-   ```
+   ```bash
    npm install -g yarn
    ```
 
 1. Clone the Front-end Template repository by running the following command:
 
-   ```
-   git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-front-end-template
+   ```bash
+   git clone https://github.com/substrate-developer-hub/substrate-front-end-template
+   # We want to use the `latest` tag throughout all of this tutorial
+   git checkout latest
    ```
 
 1. Change to the root of the front-end template directory by running the following command:
 
-   ```
+   ```bash
    cd substrate-front-end-template
    ```
 
 1. Install the dependencies for the front-end template by running the following command:
 
-   ```
+   ```bash
    yarn install
    ```
 
@@ -265,7 +269,7 @@ To start the local Substrate node:
 
 1. Start the node in development mode by running the following command:
 
-   ```
+   ```bash
    ./target/release/node-template --dev
    ```
 
@@ -278,7 +282,7 @@ To start the local Substrate node:
 
    The terminal should display output similar to this:
 
-   ```
+   ```text
    2021-11-24 15:36:35 Running in --dev mode, RPC CORS has been disabled.    
    2021-11-24 15:36:35 Substrate Node    
    2021-11-24 15:36:35 ✌️  version 4.0.0-dev-82b7c2c-aarch64-macos    
@@ -319,7 +323,7 @@ To use the Front-end Template:
 
 1. Start the Front-end template by running the following command:
 
-   ```
+   ```bash
    yarn start
    ```
 

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -439,30 +439,6 @@ finalized in bother terminal logs. Now let's use the
 and check the well known nodes of our blockchain. Don't forget to switch to one of
 our local nodes running: `127.0.0.1:9944` or `127.0.0.1:9945`.
 
-Firstly, we need to add an extra setting to tell the frontend the type of the `PeerId` used
-in node-authorization pallet. Note: the format of `PeerId` here is a wrapper on bs58 decoded
-peer id in bytes. Go to the **Settings Developer**
-[page in apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/settings/developer)
-, add following [custom type mapping](https://polkadot.js.org/docs/api/start/types.extend)
-information:
-
-```json
-// add this as is, or with other required types you have set already:
-{
-  "PeerId": "(Vec<u8>)"
-}
-```
-
-<br />
-<Message
-  type={`red`}
-  title={`Warning`}
-  text="If you don't do this, you will get extrinsic errors of the form:
-    `Verification Error: Execution(ApiError(Could not convert parameter 'tx' between node and runtime)`. 
-    More details [here](https://polkadot.js.org/docs/api/FAQ#the-node-returns-a-could-not-convert-error-on-send).
-    "
-/>
-
 Then, let's go to **Developer** page, **Chain State sub-tab**, and check the data
 stored in the `nodeAuthorization` pallet, `wellKnownNodes` storage. You should be
 able to see the peer ids of Alice and Bob's nodes, prefixed with `0x` to show its

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -105,27 +105,30 @@ the right CLI flag as offchain worker is disabled by default for non-authority n
   type={`red`}
   title={`Warning`}
   text={`Your node may not be synced with the latest block, and thus not be aware of and published updates that are 
-	  reflected in the \`node-authorization\` chain storage. You may need to disable offchain worker
-	  and manually set reachable reserved nodes for your node to sync up with the network if this is the case.`}
+    reflected in the \`node-authorization\` chain storage. You may need to disable offchain worker
+    and manually set reachable reserved nodes for your node to sync up with the network if this is the case.`}
 />
 
 ### Build the Node Template
 
-To get started: 
+To get started:
+
 1. Clone the node template.
 
-  ```bash
-  git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
-  ```
+   ```bash
+   git clone https://github.com/substrate-developer-hub/substrate-node-template
+   # We want to use the `latest` tag throughout all of this tutorial
+   git checkout latest
+   ```
 
 1. Build the node template.
 
-  ```bash
-  cd substrate-node-template/
-  cargo build --release
-  ```
-  
-  If you do run into issues building, checkout [these helpful tips](/v3/getting-started/installation#2-rust-developer-environment).
+   ```bash
+   cd substrate-node-template/
+   cargo build --release
+   ```
+
+   If you do run into issues building, checkout [these helpful tips](/v3/getting-started/installation#2-rust-developer-environment).
 
 1. Now open the code with your favorite editor, and let's make some changes.
 
@@ -152,8 +155,8 @@ std = [
 ]
 ```
 
-We need to simulate the governance in our simple blockchain, so we just let a `sudo` admin rule, configuring the pallet's interface to `EnsureRoot`. 
-In a production environment we should want to have governance based checking implemented here. 
+We need to simulate the governance in our simple blockchain, so we just let a `sudo` admin rule, configuring the pallet's interface to `EnsureRoot`.
+In a production environment we should want to have governance based checking implemented here.
 More details of this `Config` can be found in the pallet's [reference docs](/rustdocs/latest/pallet_node_authorization/pallet/trait.Config.html).
 
 **`runtime/src/lib.rs`**
@@ -191,15 +194,15 @@ Finally, we are ready to put our pallet in `construct_runtime` macro with follow
 
 ```rust
 construct_runtime!(
-    pub enum Runtime where
-        Block = Block,
-        NodeBlock = opaque::Block,
-        UncheckedExtrinsic = UncheckedExtrinsic
-    {
-        /* --snip-- */
-        NodeAuthorization: pallet_node_authorization, // <-- add this line
-        /* --snip-- */
-    }
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = opaque::Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		/* --snip-- */
+		NodeAuthorization: pallet_node_authorization, // <-- add this line
+		/* --snip-- */
+	}
 );
 ```
 
@@ -239,25 +242,25 @@ fn testnet_genesis(
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
-) -> GenesisConfig {
-  GenesisConfig {
+	) -> GenesisConfig {
+	GenesisConfig {
 
-      /* --snip-- */
+		/* --snip-- */
 
-      /*** Add This Block Item ***/
-      node_authorization: NodeAuthorizationConfig {
-        nodes: vec![
-          (
-            OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap()),
-            endowed_accounts[0].clone()
-          ),
-          (
-            OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap()),
-            endowed_accounts[1].clone()
-          ),
-          ],
-      },
-   }  
+		/*** Add This Block Item ***/
+		node_authorization: NodeAuthorizationConfig {
+		nodes: vec![
+			(
+			OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap()),
+			endowed_accounts[0].clone()
+			),
+			(
+			OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap()),
+			endowed_accounts[1].clone()
+			),
+			],
+		},
+	}
 }
 ```
 
@@ -280,8 +283,8 @@ subkey generate-node-key
   type={`gray`}
   title={`Note`}
   text="`subkey` is a CLI tool that comes bundled with substrate, and you can install it natively too! 
-	Refer to the [install Instructions](/v3/tools/subkey#installation).
-  	"
+    Refer to the [install Instructions](/v3/tools/subkey#installation).
+  "
 />
 
 The output of the command is like:
@@ -293,13 +296,17 @@ c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a // This is node
 
 Now all the code changes are finished, we are ready to launch our permissioned network!
 
-<Message
-  type={`yellow`}
-  title={`Information`}
-  text="Stuck? The solution with all required changes to the base template can be found ',
-		[here](https://github.com/substrate-developer-hub/substrate-node-template/commit/d3eaa1946d647b910a229ff7199f39d349a59e75).',
-		"
-/>
+> **Get stuck or need help?**
+> The solution with all required changes to the base template can be found [here](https://github.com/substrate-developer-hub/substrate-node-template/commit/d3eaa1946d647b910a229ff7199f39d349a59e75) for your review.
+> You can also checkout the working full solution to test against with:
+>
+> ```bash
+> # Run from your cloned node template
+> git checkout tutorials/solutions/permissioned-network
+> # Re-build the template with this source
+> cargo build --release
+> # Try out the functionality described to make sure it works
+> ```
 
 In the next section, we will use well-known node keys and Peer IDs to launch your permissioned network
 and allow access for other nodes to join.
@@ -565,7 +572,7 @@ Restart Dave's node in case it's not connecting with Charlie right away.
     "
 />
 
-🎉***Congratulations!***🎉
+🎉**_Congratulations!_**🎉
 
 You are at the end of this tutorial and are already learned about how to build a
 permissioned network. You can also play with other dispatchable calls like

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -111,36 +111,23 @@ the right CLI flag as offchain worker is disabled by default for non-authority n
 
 ### Build the Node Template
 
-If you already have Node Template cloned, you can just create a
-**check out of the v3.0.0 branch** from the base template,
-otherwise, clone this branch of the project:
+To get started: 
+1. Clone the node template.
 
-```bash
-# Fresh clone, if needed:
-git clone -b v3.0.0 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
-# From the working directory, create a new branch and check it out
-cd substrate-node-template
-git branch perm-network
-git checkout perm-network
-```
+  ```bash
+  git clone https://github.com/substrate-developer-hub/substrate-node-template
+  ```
 
-You should be able to `build` the project (or `check`) without any error:
+1. Build the node template.
 
-```bash
-cd substrate-node-template/
-cargo build --release
-```
+  ```bash
+  cd substrate-node-template/
+  cargo build --release
+  ```
+  
+  If you do run into issues building, checkout [these helpful tips](/v3/getting-started/installation#2-rust-developer-environment).
 
-<br />
-<Message
-  type={`green`}
-  title={`Tip`}
-  text="If you do run into issues building, checkout
-	[these helpful tips](/v3/getting-started/installation#2-rust-developer-environment).
-	"
-/>
-
-Now open the code with your favorite editor, and let's make some changes.
+1. Now open the code with your favorite editor, and let's make some changes.
 
 ### Add the `node-authorization` pallet
 
@@ -149,9 +136,11 @@ First we must add the pallet to our runtime dependencies:
 **`runtime/Cargo.toml`**
 
 ```TOML
-[dependencies]
-#--snip--
-pallet-node-authorization = { default-features = false, version = '3.0.0' }
+[dependencies.pallet-node-authorization]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-11-1'
+version = '4.0.0-dev'
 
 #--snip--
 [features]
@@ -163,11 +152,9 @@ std = [
 ]
 ```
 
-We need to simulate the governance in our simple blockchain, so we just let a `sudo` admin rule,
-configuring the pallet's interface to `EnsureRoot`. In a production environment we sould want to have
-difference, governance based checking implemented here. More details of this `Config` can be found in
-the pallet's
-[reference docs](/rustdocs/latest/pallet_node_authorization/pallet/trait.Config.html).
+We need to simulate the governance in our simple blockchain, so we just let a `sudo` admin rule, configuring the pallet's interface to `EnsureRoot`. 
+In a production environment we should want to have governance based checking implemented here. 
+More details of this `Config` can be found in the pallet's [reference docs](/rustdocs/latest/pallet_node_authorization/pallet/trait.Config.html).
 
 **`runtime/src/lib.rs`**
 
@@ -210,20 +197,15 @@ construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic
     {
         /* --snip-- */
-
-        /*** Add This Line ***/
-        NodeAuthorization: pallet_node_authorization::{Pallet, Call, Storage, Event<T>, Config<T>},
-
+        NodeAuthorization: pallet_node_authorization, // <-- add this line
         /* --snip-- */
-
     }
 );
 ```
 
 ### Add genesis storage for our pallet
 
-`PeerId` is encoded in bs58 format, so we need a new library
-[bs58](https://docs.rs/bs58/) in **node/Cargo.toml** to decode it to get its bytes.
+`PeerId` is encoded in bs58 format, so we need a new library [bs58](https://docs.rs/bs58/) in **node/Cargo.toml** to decode it to get its bytes.
 
 **`node/cargo.toml`**
 
@@ -258,25 +240,24 @@ fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
 ) -> GenesisConfig {
+  GenesisConfig {
 
-    /* --snip-- */
+      /* --snip-- */
 
-    /*** Add This Block Item ***/
-		node_authorization: NodeAuthorizationConfig {
-    		nodes: vec![
-				(
-					OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap()),
-					endowed_accounts[0].clone()
-				),
-				(
-					OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap()),
-					endowed_accounts[1].clone()
-				),
-    		],
-   		}),
-
-    /* --snip-- */
-
+      /*** Add This Block Item ***/
+      node_authorization: NodeAuthorizationConfig {
+        nodes: vec![
+          (
+            OpaquePeerId(bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2").into_vec().unwrap()),
+            endowed_accounts[0].clone()
+          ),
+          (
+            OpaquePeerId(bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust").into_vec().unwrap()),
+            endowed_accounts[1].clone()
+          ),
+          ],
+      },
+   }  
 }
 ```
 
@@ -316,7 +297,7 @@ Now all the code changes are finished, we are ready to launch our permissioned n
   type={`yellow`}
   title={`Information`}
   text="Stuck? The solution with all required changes to the base template can be found ',
-		[here](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/permissioned-network-v3).',
+		[here](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/permissioned-network).',
 		"
 />
 

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -297,7 +297,7 @@ Now all the code changes are finished, we are ready to launch our permissioned n
   type={`yellow`}
   title={`Information`}
   text="Stuck? The solution with all required changes to the base template can be found ',
-		[here](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/permissioned-network).',
+		[here](https://github.com/substrate-developer-hub/substrate-node-template/commit/d3eaa1946d647b910a229ff7199f39d349a59e75).',
 		"
 />
 

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -139,7 +139,7 @@ First we must add the pallet to our runtime dependencies:
 [dependencies.pallet-node-authorization]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-11-1'
+tag = 'devhub/latest'
 version = '4.0.0-dev'
 
 #--snip--

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -115,7 +115,7 @@ To get started:
 1. Clone the node template.
 
   ```bash
-  git clone https://github.com/substrate-developer-hub/substrate-node-template
+  git clone -b latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
   ```
 
 1. Build the node template.

--- a/v3/tutorials/04-forkless-upgrades/index.mdx
+++ b/v3/tutorials/04-forkless-upgrades/index.mdx
@@ -116,7 +116,7 @@ clients, the first step of this tutorial is to start the template node as-is. Bu
 unmodified [Node Template](https://github.com/substrate-developer-hub/substrate-node-template).
 
 ```shell
-cargo run --release -- --dev --tmp
+cargo run --release -- --dev 
 ```
 
 <br />
@@ -225,11 +225,11 @@ First, add the Scheduler pallet as a dependency in the template node's runtime C
 **`runtime/Cargo.toml`**
 
 ```toml
-   [dependencies.pallet-scheduler]
-   default-features = false
-   git = 'https://github.com/paritytech/substrate.git'
-   tag = 'monthly-2021-10'
-   version = '4.0.0-dev'
+[dependencies.pallet-scheduler]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-11-1'
+version = '4.0.0-dev'
 
 #--snip--
 
@@ -263,6 +263,7 @@ impl pallet_scheduler::Config for Runtime {
 	type ScheduleOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxScheduledPerBlock = MaxScheduledPerBlock;
 	type WeightInfo = ();
+  type OriginPrivilegeCmp = EqualPrivilegeOnly;
 }
 
 // Add the Scheduler pallet inside the construct_runtime! macro.
@@ -273,9 +274,15 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		/*** snip ***/
-		Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>},
+		Scheduler: pallet_scheduler,
 	}
 );
+```
+
+Add the following trait dependency at the top of the file:
+
+```rust
+pub use frame_support::EqualPrivilegeOnly;
 ```
 
 The final step to preparing an upgraded FRAME runtime is to increment its
@@ -333,7 +340,7 @@ cargo build --release -p node-template-runtime
   type={`yellow`}
   title={`Information`}
   text="Here is a
-	  [solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/runtime-upgrade-v3)
+	  [solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/runtime-upgrade)
 	  to check against in case you\'re stuck. See the `diff` in the commit history for details.
 	  "
 />
@@ -354,8 +361,7 @@ more about building Rust code with Cargo.
 
 ### Upgrade the Runtime
 
-Use this link to open the Polkadot JS Apps UI and automatically configure the UI to connect to the
-local node: https://polkadot.js.org/apps/#/extrinsics?rpc=ws://127.0.0.1:9944.
+Use [this link](https://polkadot.js.org/apps/#/extrinsics?rpc=ws://127.0.0.1:9944) to open the Polkadot JS Apps UI and automatically configure the UI to connect to the local node.
 
 <Message
   type={`green`}
@@ -463,7 +469,9 @@ In the previous section, the Scheduler pallet was configured with the `Root` ori
 [`ScheduleOrigin`](/rustdocs/latest/pallet_scheduler/trait.Config.html#associatedtype.ScheduleOrigin),
 which means that the `sudo` function (_not_ `sudo_unchecked_weight`) can be used to invoke the
 `schedule` function. Use this link to open the Polkadot JS Apps UI's Sudo tab:
-https://polkadot.js.org/apps/#/sudo?rpc=ws://127.0.0.1:9944. Wait until all the other fields have
+https://polkadot.js.org/apps/#/sudo?rpc=ws://127.0.0.1:9944. 
+
+Wait until all the other fields have
 been filled in before providing the `when` parameter. Leave the `maybe_periodic` parameter empty and
 the `priority` parameter at its default value of `0`. Select the System pallet's `set_code` function
 as the `call` parameter and provide the Wasm binary as before. Leave the "with weight override"
@@ -489,4 +497,4 @@ app to query the `existentialDeposit` constant value from the Balances pallet.
 
 - Learn about [storage migrations](/v3/runtime/upgrades#storage-migrations) and
   attempt one alongside a runtime upgrade.
-- Explore the [how-to guides section on storage migrations](/how-to-guides/v3/storage-migrations/basics)
+- Explore the [how-to guides section on storage migrations](/how-to-guides/v3/storage-migrations/basics).

--- a/v3/tutorials/04-forkless-upgrades/index.mdx
+++ b/v3/tutorials/04-forkless-upgrades/index.mdx
@@ -228,7 +228,7 @@ First, add the Scheduler pallet as a dependency in the template node's runtime C
 [dependencies.pallet-scheduler]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-11-1'
+tag = 'devhub/latest'
 version = '4.0.0-dev'
 
 #--snip--

--- a/v3/tutorials/06-node-metrics/index.mdx
+++ b/v3/tutorials/06-node-metrics/index.mdx
@@ -113,7 +113,7 @@ Prometheus->Grafana: `substrate_peers_count (1582023828, 5), (1582023847, 4) [..
   text="We suggest for _testing_ that you download the compiled `bin` programs for these apps
     as opposed to fully installing them or using them in docker. Just `download` for your
     architecture, and run it from the `working directory` that is convenient for you.
-    The links above provide instruction on this, and this guide assume you do it this way.
+    The links above provide instructions on this, and this guides assume you do it this way.
     "
 />
 
@@ -143,7 +143,7 @@ be accessed over an interface other than local host with
 # start the template node  in dev & tmp mode to experiment
 # optionally add the `--prometheus-port <PORT>`
 # or `--prometheus-external` flags
-./target/release/node-template --dev --tmp
+./target/release/node-template --dev
 ```
 
 ### Configure Prometheus to scrape your Substrate node
@@ -264,8 +264,8 @@ If you do create one, consider uploading it to the [community list of
 dashboards](https://grafana.com/grafana/dashboards) and letting the Substrate
 builder community know it exists by listing in on [Awesome
 Substrate](https://github.com/substrate-developer-hub/awesome-substrate)! Here
-is ours on [the grafana public
-dashboards](https://grafana.com/grafana/dashboards/13759/)
+is ours on [the Grafana public
+dashboard](https://grafana.com/grafana/dashboards/13759/).
 
 ## Next Steps
 

--- a/v3/tutorials/06-node-metrics/index.mdx
+++ b/v3/tutorials/06-node-metrics/index.mdx
@@ -113,7 +113,7 @@ Prometheus->Grafana: `substrate_peers_count (1582023828, 5), (1582023847, 4) [..
   text="We suggest for _testing_ that you download the compiled `bin` programs for these apps
     as opposed to fully installing them or using them in docker. Just `download` for your
     architecture, and run it from the `working directory` that is convenient for you.
-    The links above provide instructions on this, and this guides assume you do it this way.
+    The preceding links provide instructions for downloading the compiled programs, and this guide assumes you follow those instructions.
     "
 />
 

--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -78,7 +78,7 @@ To add the Nicks pallet to the Substrate node template:
    [dependencies.pallet-nicks]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'monthly-2021-10'
+   tag = 'monthly-2021-11-1'
    version = '4.0.0-dev'
    ```
 
@@ -99,7 +99,7 @@ For an introduction to editing `Cargo.toml` files, see the [Cargo reference docu
      ...
      'pallet-aura/std',
      'pallet-balances/std',
-     'pallet-nicks/std',
+     'pallet-nicks/std', # add this line
      ...
    ]
    ```
@@ -287,10 +287,10 @@ To implement the nicks pallet in your runtime:
        UncheckedExtrinsic = UncheckedExtrinsic
      {
        /* --snip-- */
-       Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+       Balances: pallet_balances,
 
        /*** Add This Line ***/
-       Nicks: pallet_nicks::{Pallet, Call, Storage, Event<T>},
+       Nicks: pallet_nicks,
      }
    );
    ```
@@ -324,16 +324,13 @@ To start the local Substrate node:
 1. Start the node in development mode by running the following command:
 
    ```
-   ./target/release/node-template --dev --tmp
+   ./target/release/node-template --dev
    ```
 
    The node-template command-line options specify how you want the running node to operate.
-   In this case, the options specify the following:
-
-   - The `--dev` option specifies that the node run as a developer node chain specification.
-
-   - The `--tmp` option specifies that the node save all active data—such as keys, blockchain database, and networking information—while it is running, then delete the data when you stop the node by pressing Control-c.
-     You should use `--tmp` option to ensure you have a clean working state any time you stop and restart the node.
+   In this case, the `--dev` option specifies that the node run as a developer node chain specification.
+   By default this option implies that the node will save all active data—such as keys, blockchain database, and networking information—while it is running, then delete the data when you stop the node by pressing Control-c.
+   This also ensures you have a clean working state any time you stop and restart the node.
 
 1. Verify your node is up and running successfully by reviewing the output displayed in the terminal.
 

--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -328,9 +328,9 @@ To start the local Substrate node:
    ```
 
    The node-template command-line options specify how you want the running node to operate.
-   In this case, the `--dev` option specifies that the node run as a developer node chain specification.
-   By default this option implies that the node will save all active data—such as keys, blockchain database, and networking information—while it is running, then delete the data when you stop the node by pressing Control-c.
-   This also ensures you have a clean working state any time you stop and restart the node.
+In this case, the `--dev` option specifies that the node runs in developer mode using the predefined `development` chain specification.
+   By default, this option also deletes all active data—such as keys, the blockchain database, and networking information when you stop the node by pressing Control-c.
+   Using the `--dev` option ensures that you have a clean working state any time you stop and restart the node.
 
 1. Verify your node is up and running successfully by reviewing the output displayed in the terminal.
 

--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -78,7 +78,7 @@ To add the Nicks pallet to the Substrate node template:
    [dependencies.pallet-nicks]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'monthly-2021-11-1'
+   tag = 'devhub/latest'
    version = '4.0.0-dev'
    ```
 

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -255,7 +255,7 @@ Just like the [helper files](https://github.com/substrate-developer-hub/substrat
    [dependencies.sp-io]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'monthly-2021-11-1'
+   tag = 'devhub/latest'
    version = '4.0.0-dev'
    ```
 
@@ -265,16 +265,6 @@ Just like the [helper files](https://github.com/substrate-developer-hub/substrat
    ```bash
    cargo build -p pallet-kitties
    ```
-
-<br />
-<Message
-  type={`red`}
-  title={`Warning`}
-  text={`
-Check that you're using the correct \`monthly-*\` tag and version otherwise you will get a
-dependency error. Here, we're using the \`monthly-2021-11-1\` tag of Substrate.
-  `}
-/>
 
 You'll notice the Rust compiler giving you warnings about unused imports.
 That's fine!


### PR DESCRIPTION
Closes #606 (as well as other items in #132). This also implies closing [this tracking issue](https://github.com/substrate-developer-hub/substrate-docs/issues/600).

The reason I used a separate tracking issue was because the work here updates the tutorial write-ups with relevant latest Substrate updates.  #600 helped me keep track of both the "docs" work and the "template update" work which I did synchronously. For the docs stuff here, updates included: 

- Updating all `git clone` commands to clone the latest node template at master (all at `monthly-2021-11-1`)
- Removing the need to specify custom types in Polkadot JS Apps UI
- Updating according to new pallet declaration in `construct_runtime!`
- No longer needing to specify `--tmp` when launching a chain

I've compiled and tested all solutions and tutorial instructions accordingly. ✅

Once this updates and we figure out #588, all we'll have to do is find-and-replace `monthly-2021-11-1` with `latest` throughout our docs and node template solutions. 

cc: @NukeManDan 
