### PR TITLE
Fixed typo in /07-add-a-pallet/index.mdx

### DIFF
--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -237,7 +237,7 @@ interface for the Nicks pallet.
   }
   ```
 
-The `impl pallet_balances::Config` block allows your to configure the types and parameters that are
+The `impl pallet_balances::Config` block allows you to configure the types and parameters that are
 specified by the Balances pallet `Config` trait.
 For example, this `impl` block configures the Balances pallet to use the `u128` type to track balances.
 If you were developing a chain where it was important to optimize storage, you could use any unsigned


### PR DESCRIPTION
Typo fix in "Add the Nicks Pallet to your Runtime" tutorial