### PR TITLE
Remove extra line of `generate_storage_info`

### DIFF
--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -137,7 +137,6 @@ Therefore, the first step is to remove some files and content from the files in 
    #[pallet::error]   // <-- Step 4. code block will replace this.
    #[pallet::pallet]
    #[pallet::generate_store(pub(super) trait Store)]
-   #[pallet::generate_storage_info]
    pub struct Pallet<T>(_);
 
    #[pallet::storage] // <-- Step 5. code block will replace this.


### PR DESCRIPTION
Compare with [final solution](https://github.com/substrate-developer-hub/substrate-node-template/blob/tutorials/solutions/proof-of-existence/pallets/template/src/lib.rs), there isn't this line of code exists. And it will cause "the trait `MaxEncodedLen` is not implemented for `Vec<u8>`" error thrown and stop the cargo check process.