### PR TITLE
Fix typo in command arguments

### DIFF
--- a/v3/docs/03-runtime/i-benchmarking/index.mdx
+++ b/v3/docs/03-runtime/i-benchmarking/index.mdx
@@ -158,7 +158,7 @@ Here's an example of launching a node with benchmarking features enabled:
     --execution wasm \          # Always test with Wasm
     --wasm-execution compiled \ # Always used `wasm-time`
     --pallet pallet_example \   # Select the pallet
-    --extrinsic '\*' \          # Select the benchmark case name, using '*' for all
+    --extrinsic '*' \          # Select the benchmark case name, using '*' for all
     --steps 20 \                # Number of steps across component ranges
     --repeat 10 \               # Number of times we repeat a benchmark
     --raw \                     # Optionally output raw benchmark data to stdout


### PR DESCRIPTION
Fix typo in command arguments of launching a node with benchmarking features enabled