### PR TITLE
Docs: remove indent in paragraphs

### DIFF
--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -164,10 +164,10 @@ rustc --version
 rustup show
 ```
 
-    The previous steps walked you through the installation and configuration of Rust and the Rust toolchain so that you could see the full process for yourself.
+The previous steps walked you through the installation and configuration of Rust and the Rust toolchain so that you could see the full process for yourself.
 
-    It is also possible to automate the steps using a script.
-    If you want to try installing and configuring Rust using a script, see the [`getsubstrate`](https://getsubstrate.io) automation script.
+It is also possible to automate the steps using a script.
+If you want to try installing and configuring Rust using a script, see the [`getsubstrate`](https://getsubstrate.io) automation script.
 
 ## Set up a development environment
 


### PR DESCRIPTION
Removes indentation of the last two paragraphs of the "Install Rust and the Rust toolchain" section.
This was causing the text to show in monospace font and broke a hyperlink.

![Screen Shot 2021-12-06 at 20 02 15](https://user-images.githubusercontent.com/12701614/144937271-e143a345-9d5c-41de-9880-067b15e3adb8.png)


