### PR TITLE
Remove some FRAME v1 leftovers

### DIFF
--- a/v3/docs/03-runtime/e-storage/index.mdx
+++ b/v3/docs/03-runtime/e-storage/index.mdx
@@ -180,7 +180,7 @@ getter method implemented on the module; instead, you will need to use
 <Message
   type={`gray`}
   title={`Note`}
-  text={`The optional \`get\` and \`getter\` extensions only
+  text={`The optional \`getter\` extension only
   impact the way that a storage item can be accessed from _within_ Substrate code &mdash; you will always be
   able to [query the storage of your runtime](/v3/advanced/storage#Querying-Storage) to get the value
   of a storage item.`}
@@ -340,9 +340,9 @@ In `chain_spec.rs`:
 
 ```rust
 GenesisConfig {
-    my_pallet: Some(MyPalletConfig {
+    my_pallet: MyPalletConfig {
         init_val: 221u64 + SOME_CONSTANT_VALUE,
-    }),
+    },
 }
 ```
 

--- a/v3/docs/03-runtime/e-storage/index.mdx
+++ b/v3/docs/03-runtime/e-storage/index.mdx
@@ -89,7 +89,7 @@ elements of a native list, map iterations are significantly _more_ costly than l
   text={`In general, Substrate focuses on programming according to principles and [best practices](#best-practices)
   as opposed to hard and fast rules of right and wrong. The information here aims to help you understand _all_ of Substrate's
   storage capabilities and how to use them in a way that respects the principles around which
-  they were designed. For instance, iterating over storage maps in your runtime is neither right nor 
+  they were designed. For instance, iterating over storage maps in your runtime is neither right nor
   wrong &mdash; yet, avoiding it would be considered a better approach with respect to best practices.`}
 />
 
@@ -259,7 +259,7 @@ performance. Read more about common hashers in Subsrate in [this section](#commo
   type={`gray`}
   title={`Note`}
   text={`Cryptographic hashing algorithms are more complex and resource-intensive than their
-  non-cryptographic counterparts, which is why it is important for runtime engineers to understand 
+  non-cryptographic counterparts, which is why it is important for runtime engineers to understand
   their appropriate usages in order to make the best use of the flexibility Substrate provides.`}
 />
 
@@ -368,9 +368,9 @@ struct GenesisConfig {
 #[pallet::genesis_build]
 impl<T: Config> GenesisBuild<T> for GenesisConfig {
     fn build(&self) {
-        Pallet::<T>::initialize_members(&config.members);
+        Pallet::<T>::initialize_members(&self.members);
         SomeStorageItem::<T>::put(self.prime);
-  }
+    }
 }
 ```
 
@@ -378,9 +378,10 @@ In `chain_spec.rs`:
 
 ```rust
 GenesisConfig {
-    my_pallet: Some(MyPalletConfig {
-        orig_ids: LIST_OF_IDS,
-    }),
+    my_pallet: MyPalletConfig {
+        members: LIST_OF_IDS,
+        prime: ID,
+    },
 }
 ```
 
@@ -404,7 +405,7 @@ impl<T: Config> GenesisBuild<T> for GenesisConfig {
     fn build(&self) {
         Pallet::<T>::initialize_members(&config.members);
         SomeStorageItem::<T>::put(self.prime);
-  }
+    }
 }
 ```
 
@@ -412,9 +413,10 @@ In `chain_spec.rs`:
 
 ```rust
 GenesisConfig {
-    my_pallet: Some(MyPalletConfig {
-        orig_ids: LIST_OF_IDS,
-    }),
+    my_pallet: MyPalletConfig {
+        members: LIST_OF_IDS,
+        prime: ID,
+    },
 }
 ```
 


### PR DESCRIPTION
- `get` extension for storage accessors has been removed
- `GenesisConfig` elements are not defined as  `Option`s