### PR TITLE
Broken code snippet (POE tutorial)

### DIFF
--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -137,7 +137,6 @@ Therefore, the first step is to remove some files and content from the files in 
    	#[pallet::error]   // <-- Step 4. code block will replace this.
    	#[pallet::pallet]
    	#[pallet::generate_store(pub(super) trait Store)]
-   	#[pallet::generate_storage_info]
    	pub struct Pallet<T>(_);
 
    	#[pallet::storage] // <-- Step 5. code block will replace this.


### PR DESCRIPTION
In the "Build a proof of existence dApp tutorial", the substrate template will not build with the snippet given, due to the line `#[pallet::generate_storage_info]`:

<img width="803" alt="Screen Shot 2021-12-14 at 6 15 31 PM" src="https://user-images.githubusercontent.com/5394797/146100010-af35756a-1acf-4c6e-90ba-8a1c1dbedafa.png">

It builds with the line removed. The [working code example](https://github.com/substrate-developer-hub/substrate-node-template/blob/773d72752f3598e5d405b48c6f716f4153c95070/pallets/template/src/lib.rs) given at the end of the tutorial has this line removed. 
