### PR TITLE
[Cumulus Tutorial] Fix collator block formation

### DIFF
--- a/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
+++ b/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
@@ -242,7 +242,7 @@ At this point your _collator's logs_ should look something like this:
 ```
 
 You should see your collator node running (alone) and peering with the already running relay chain nodes.
-Note if you do not see the embedded relaychain peering with local relay chain node, try disabling your firewall or adding the `bootnodes` parameter with the relay node's address. 
+> Note if you do not see the embedded relaychain peering with local relay chain node, try disabling your firewall or adding the `bootnodes` parameter with the relay node's address. 
 
 It has not started authoring parachain blocks yet.
 Authoring will begin when the collator is actually **registered on the relay chain**.

--- a/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
+++ b/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
@@ -181,12 +181,13 @@ Notice that we need to supply the same relay chain chain spec we used for launch
 -- \
 --execution wasm \
 --chain <relay chain raw chain spec> \
+--bootnodes /ip4/<Alice Relay IP>/tcp/30333/p2p/<Alice Relay Peer ID> \
 --port 30343 \
 --ws-port 9977
 ```
 
 The first thing to notice about this command is that several arguments are passed before the lone `--`, and several more arguments passed after it.
-A parachain collator contains the actual collator node and also an **embedded relay chain node**. The arguments before the `--` are for the collator, and the arguments after the `--` are for the embedded relay chain node.
+A parachain collator contains the actual collator node and also an **embedded relay chain node**. The arguments before the `--` are for the collator, and the arguments after the `--` are for the embedded relay chain node. The embedded relay node needs to connect to the local relay chain via the `bootnodes` parameter.
 
 We give the collator a base path and ports as we did for the relay chain node previously.
 We also specify the para ID.

--- a/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
+++ b/v3/tutorials/09-cumulus/b-connecting-to-relay/index.mdx
@@ -181,13 +181,12 @@ Notice that we need to supply the same relay chain chain spec we used for launch
 -- \
 --execution wasm \
 --chain <relay chain raw chain spec> \
---bootnodes /ip4/<Alice Relay IP>/tcp/30333/p2p/<Alice Relay Peer ID> \
 --port 30343 \
 --ws-port 9977
 ```
 
 The first thing to notice about this command is that several arguments are passed before the lone `--`, and several more arguments passed after it.
-A parachain collator contains the actual collator node and also an **embedded relay chain node**. The arguments before the `--` are for the collator, and the arguments after the `--` are for the embedded relay chain node. The embedded relay node needs to connect to the local relay chain via the `bootnodes` parameter.
+A parachain collator contains the actual collator node and also an **embedded relay chain node**. The arguments before the `--` are for the collator, and the arguments after the `--` are for the embedded relay chain node.
 
 We give the collator a base path and ports as we did for the relay chain node previously.
 We also specify the para ID.
@@ -243,6 +242,8 @@ At this point your _collator's logs_ should look something like this:
 ```
 
 You should see your collator node running (alone) and peering with the already running relay chain nodes.
+Note if you do not see the embedded relaychain peering with local relay chain node, try disabling your firewall or adding the `bootnodes` parameter with the relay node's address. 
+
 It has not started authoring parachain blocks yet.
 Authoring will begin when the collator is actually **registered on the relay chain**.
 


### PR DESCRIPTION
Updating the tutorial documentation for [Connecting a Parachain](https://docs.substrate.io/tutorials/v3/cumulus/connect-parachain/#start-the-collator-node) Adding the `bootnodes` parameter to collator node start command. This connects the embedded relay node to local relay chain so blocks will form on the parachain after registered and an epoch has passed.

Linked issue: https://github.com/substrate-developer-hub/substrate-docs/issues/707