### PR TITLE
remove community resources link

### DIFF
--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -132,11 +132,6 @@ const MainNav = {
                 link: `${site}/ecosystem/resources/awesome-substrate`,
                 external: true,
               },
-              {
-                linkTitle: 'Community Resources',
-                link: `${site}/ecosystem/resources/community-resources`,
-                external: true,
-              },
             ],
           },
           {


### PR DESCRIPTION
This removes Community Resources menu item from global menu.

Reason: this page has been decommissioned
(https://substrate.io/ecosystem/resources/community-resources/)