### PR TITLE
rewrapped descriptions so work better on small screens

### DIFF
--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -132,11 +132,6 @@ const MainNav = {
                 link: `${site}/ecosystem/resources/awesome-substrate`,
                 external: true,
               },
-              {
-                linkTitle: 'Community Resources',
-                link: `${site}/ecosystem/resources/community-resources`,
-                external: true,
-              },
             ],
           },
           {

--- a/v3/docs/01-getting-started/e-glossary/index.mdx
+++ b/v3/docs/01-getting-started/e-glossary/index.mdx
@@ -63,7 +63,7 @@ In a proof-of-work blockchain, these nodes are called _miners_.
 
 ## authority
 
-The [nodes](#node) that act as a collective to manage [consensus](#consensus) on a[blockchain](#blockchain) network. 
+The [nodes](#node) that act as a collective to manage [consensus](#consensus) on a [blockchain](#blockchain) network. 
 In a [proof-of-stake](#nominated-proof-of-stake-npos) blockchain—for example, a blockchain that us the [Staking pallet](/v3/runtime/frame#staking) from [FRAME](#frame)—authorities are determined through a token-weighted nomination and voting system.
 
 > The terms _authorities_ and _[validators](#validator)_ sometimes seem to refer the same thing.
@@ -163,7 +163,7 @@ For information about how the database backend is implemented and used by Substr
 ## dev phrase
 
 A [mnemonic phrase](https://en.wikipedia.org/wiki/Mnemonic#For_numerical_sequences_and_mathematical_operations) that is intentionally made public. 
-All of the[well-known development accounts](/v3/tools/subkey#well-known-keys) (Alice, Bob, Charlie, Dave, Eve, and Ferdie) are generated from the same dev phrase. 
+All of the [well-known development accounts](/v3/tools/subkey#well-known-keys) (Alice, Bob, Charlie, Dave, Eve, and Ferdie) are generated from the same dev phrase. 
 The dev phrase is:
 `bottom drive obey lake curtain smoke basket hold race lonely fit walk`
 
@@ -303,7 +303,7 @@ synchronization of the chain.
 
 ## hybrid consensus
 
-A blockchain consensus protocol that consists of independent or loosely-coupled mechanisms for[block production](#author) and [finality](#finality). 
+A blockchain consensus protocol that consists of independent or loosely-coupled mechanisms for [block production](#author) and [finality](#finality). 
 Hybrid consensus allows the chain to grow as fast as probabilistic consensus protocols, such as [Aura](#aura-aka-authority-round), while maintaining the same level of security as [deterministic finality](#deterministic-finality) consensus protocols, such as [GRANDPA](#grandpa). 
 In general, block production algorithms tend to be faster than finality mechanisms.
 Making block production separate from block finalization gives Substrate developers greater control of their chain's performance.
@@ -338,7 +338,7 @@ A light client is capable of verifying [cryptographic primitives](#cryptographic
 ## macro
 
 A programming language feature that enables developers to write a sequence of instructions that can be named and executed together. 
-The [FRAME](#frame)development environment provides several [macros](/v3/runtime/macros) for [Rust](https://doc.rust-lang.org/1.7.0/book/macros.html) that you can use to compose a [runtime](#runtime).
+The [FRAME](#frame) development environment provides several [macros](/v3/runtime/macros) for [Rust](https://doc.rust-lang.org/1.7.0/book/macros.html) that you can use to compose a [runtime](#runtime).
 
 ## metadata
 

--- a/v3/docs/07-advanced/h-ss58/index.mdx
+++ b/v3/docs/07-advanced/h-ss58/index.mdx
@@ -76,7 +76,7 @@ There are 16 different address formats, identified by the length (**in bytes**) 
 Several potential checksum strategies exist within Substrate, giving different length and longevity guarantees.
 There are two types of checksum preimages (known as SS58 and AccountID) and many different checksum lengths (1 to 8 bytes).
 
-In all cases for Substrate, the [Blake2-256](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)>) hash function is used.
+In all cases for Substrate, the Blake2b-512 ([Spec](https://datatracker.ietf.org/doc/html/rfc7693), [Wiki](https://en.wikipedia.org/wiki/BLAKE_(hash_function))) hash function is used (OID 1.3.6.1.4.1.1722.12.2.1.16).
 The variants simply select the preimage used as the input to the hash function and the number of bytes taken from its output.
 
 The bytes used are always the left most bytes.

--- a/v3/how-to-guides/01-basics/b-instantiable-pallets/index.mdx
+++ b/v3/how-to-guides/01-basics/b-instantiable-pallets/index.mdx
@@ -33,10 +33,10 @@ category: basics
     {
       title: 'Overview',
       description: `
-        Instantiable pallets provide separate storage items for a runtime that contains more than one reference to the same pallet.
-        This is useful in cases where you want to reuse the logic provided by a single pallet.
-        This procedure shows you how to create two instances of the same pallet and how to configure their
-        capabilities.
+        Instantiable pallets provide separate storage items for a runtime that contains more
+        than one reference to the same pallet. This is useful in cases where you want to
+        reuse the logic provided by a single pallet. This procedure shows you how to create
+        two instances of the same pallet and how to configure their capabilities.
       `,
     },
   ]}

--- a/v3/how-to-guides/01-basics/e-custom-chainspec/index.mdx
+++ b/v3/how-to-guides/01-basics/e-custom-chainspec/index.mdx
@@ -34,7 +34,8 @@ keywords:
       title: 'Overview',
       description: `
         Once you have a Substrate node crafted, you want to start a network with many peers!
-        This guide shows one method to create chain specification files uniformly and distribute them so other nodes can discover and peer with your network _explicitly_.
+        This guide shows one method to create chain specification files uniformly and
+        distribute them so other nodes can discover and peer with your network _explicitly_.
       `,
     },
   ]}

--- a/v3/how-to-guides/01-basics/e-helper-functions/index.mdx
+++ b/v3/how-to-guides/01-basics/e-helper-functions/index.mdx
@@ -26,10 +26,14 @@ category: basics
     {
       title: 'Overview',
       description: `
-        Sometimes a dispatchable function inside a pallet reuses logic that is common to other dispatchables.
-        In this case, it's useful to refactor this logic into its own private function.
-        At other times, dispatchable functions get increasingly difficult to read as the amount of code increases to perform various checks within the dispatchable. In both instances, using helper functions that cannot be accessed from outside the pallet are a useful tool to optimize for code readability and reusability.
-        In this guide, we'll see how to create an adder helper that checks for arithmetic overflow and can be reused in any dispatchable.`,
+        Sometimes a dispatchable function inside a pallet reuses logic that is common to other
+        dispatchables. In this case, it's useful to refactor this logic into its own private
+        function. At other times, dispatchable functions get increasingly difficult to read
+        as the amount of code increases to perform various checks within the dispatchable.
+        In both instances, using helper functions that cannot be accessed from outside the pallet
+        are a useful tool to optimize for code readability and reusability.
+        In this guide, we'll see how to create an adder helper that checks for arithmetic
+        overflow and can be reused in any dispatchable.`,
     },
   ]}
 />

--- a/v3/how-to-guides/01-basics/f-mint-token/index.mdx
+++ b/v3/how-to-guides/01-basics/f-mint-token/index.mdx
@@ -39,8 +39,11 @@ category: basics
     {
       title: 'Overview',
       description: `
-        This guide will step you through an effective way to mint a token by leveraging the primitive capabilities that [StorageMap](/rustdocs/latest/frame_support/storage/trait.StorageMap.html) gives us.
-        To achieve this, this "primitive" approach uses the [blake2_128_concat](/v3/runtime/storage#hashing-algorithms) \`hasher\` to map balances to account IDs, similar to how the [Balances](/rustdocs/latest/pallet_balances/index.html) pallet makes use of it to store and keep track of account balances.
+        This guide will step you through an effective way to mint a token by leveraging the
+        primitive capabilities that [StorageMap](/rustdocs/latest/frame_support/storage/trait.StorageMap.html) gives us.
+        To achieve this, this "primitive" approach uses the [blake2_128_concat](/v3/runtime/storage#hashing-algorithms) \`hasher\` to map balances
+        to account IDs, similar to how the [Balances](/rustdocs/latest/pallet_balances/index.html) pallet makes use of
+        it to store and keep track of account balances.
 	    `,
     },
   ]}

--- a/v3/how-to-guides/01-basics/g-weights/index.mdx
+++ b/v3/how-to-guides/01-basics/g-weights/index.mdx
@@ -39,12 +39,16 @@ category: basics
     {
       title: 'Overview',
       description: `
-        Weights are an important part of Substrate development because they provide information about the maximum cost of a function in terms of the block size it will take up.
-        This way, the [weighting system](/v3/concepts/weight) checks what the cost will be before a function is executed.
+        Weights are an important part of Substrate development because they provide information
+        about the maximum cost of a function in terms of the block size it will take up.
+        This way, the [weighting system](/v3/concepts/weight) checks what the cost will be before
+        a function is executed.
         As runtime engineers, we care a lot about weights.
-        Not only do they help add security checks around the functions we create, but they also force us to think about the computational ressources consumed by a transaction.
+        Not only do they help add security checks around the functions we create, but they also
+        force us to think about the computational ressources consumed by a transaction.
         From that, we can figure out [what fees to charge](/v3/runtime/weights-and-fees) users.
-        This guide will cover how to calculate the maximum weight for a dispatch call; calculate the actual weight after execution; and reimburse the difference.
+        This guide will cover how to calculate the maximum weight for a dispatch call; calculate
+        the actual weight after execution; and reimburse the difference.
         Here's an overview of the traits we'll be implementing:
         - [\`PaysFee\`](/rustdocs/latest/frame_support/weights/trait.PaysFee.html): to specify whether or not a dispatch pays the fee.
         - [\`GetDispatchInfo\`](/rustdocs/latest/frame_support/weights/trait.GetDispatchInfo.html): carries weight information using the \`#[weight]\` attribute.

--- a/v3/how-to-guides/02-pallet-design/d-simple-crowdfund/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/d-simple-crowdfund/index.mdx
@@ -32,14 +32,16 @@ category: pallet design
     },
     {
       title: 'Overview',
-      description: `Using a child trie provides two advantages over using standard storage. First, it allows for
-        removing the entirety of the trie is a single storage write when the fund is dispensed or
-        dissolved. Second, it allows any contributor to prove that they contributed using a Merkle Proof.
-        This guide demonstrates how to use one trie for each active crowdfund. Any user can start a crowdfund by
-        specifying a goal amount for the crowdfund, an end time, and a beneficiary who will
-        receive the pooled funds if the goal is reached by the end time. If the fund is not successful, it enters into a
-        retirement period when contributors can reclaim their pledged funds. Finally, an unsuccessful fund can be dissolved,
-        sending any remaining tokens to the user who dissolves it.`,
+      description: `Using a child trie provides two advantages over using standard storage.
+        First, it allows for removing the entirety of the trie is a single storage write when
+        the fund is dispensed or dissolved. Second, it allows any contributor to prove that
+        they contributed using a Merkle Proof. This guide demonstrates how to use one trie
+        for each active crowdfund. Any user can start a crowdfund by specifying a goal amount
+        for the crowdfund, an end time, and a beneficiary who will receive the pooled funds
+        if the goal is reached by the end time. If the fund is not successful, it enters into a
+        retirement period when contributors can reclaim their pledged funds. Finally, an
+        unsuccessful fund can be dissolved, sending any remaining tokens to the user who
+        dissolves it.`,
     },
   ]}
 />

--- a/v3/how-to-guides/02-pallet-design/e-storage-value/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/e-storage-value/index.mdx
@@ -23,8 +23,9 @@ category: pallet design
     },
     {
       title: 'Overview',
-      description: `Creating a struct of similarly grouped storage items is a neat way to keep track of them.
-		They can be easier to reference than keeping individual \`StorageValue\` items separate this way.
+      description: `Creating a struct of similarly grouped storage items is a neat way to
+	    keep track of them. They can be easier to reference than keeping individual
+		\`StorageValue\` items separate this way.
 		In addition, they can be used to ease testing and genesis configuration.
 		This guide steps through the procedure of creating a struct in storage which:
 - Keeps track of an initial amount (\`issuance\`)

--- a/v3/how-to-guides/02-pallet-design/f-tight-coupling/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/f-tight-coupling/index.mdx
@@ -20,10 +20,10 @@ keywords: []
     },
     {
       title: 'Overview',
-      description: `Tight coupling two pallets may suit specific use cases where the outside pallet 
-         contains many types and methods common to those of the initial pallet. If this is not 
-         the case, it's recommended to use loose coupling instead. Read more about pallet 
-         coupling [here](/v3/runtime/pallet-coupling).`,
+      description: `Tight coupling two pallets may suit specific use cases where the
+         outside pallet contains many types and methods common to those of the initial
+         pallet. If this is not the case, it's recommended to use loose coupling instead.
+         Read more about pallet coupling [here](/v3/runtime/pallet-coupling).`,
     },
   ]}
 />

--- a/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
@@ -19,9 +19,10 @@ keywords: []
     },
     {
       title: 'Overview',
-      description: `Loose coupling is a technique that enables re-using logic from another pallet inside a pallet. In this guide
-        we show the simple pattern of using a type from an outside pallet in our working pallet, by using
-        trait bounds in our pallet's configuration trait. We will loosely couple a pallet to make use of the \`Currency\` trait
+      description: `Loose coupling is a technique that enables re-using logic from another
+        pallet inside a pallet. In this guide we show the simple pattern of using a type from
+        an outside pallet in our working pallet, by using trait bounds in our pallet's
+        configuration trait. We will loosely couple a pallet to make use of the \`Currency\` trait
         from [\`frame_support\`](/rustdocs/latest/frame_support/traits/tokens/currency/trait.Currency.html).`,
     },
   ]}

--- a/v3/how-to-guides/03-weights/b-benchmarking/index.mdx
+++ b/v3/how-to-guides/03-weights/b-benchmarking/index.mdx
@@ -25,7 +25,8 @@ category: weights
       title: 'Overview',
       description: `
         This guide steps throught the process of adding benchmarking to a pallet and runtime.
-        In addition, it covers the steps of writing a simple benchmark for a pallet as well as testing and running the benchmarking tool.
+        In addition, it covers the steps of writing a simple benchmark for a pallet as well
+        as testing and running the benchmarking tool.
         This guide does not cover updating weights with benchmarked values.
       `,
     },

--- a/v3/how-to-guides/03-weights/c-using-benchmark-weights/index.mdx
+++ b/v3/how-to-guides/03-weights/c-using-benchmark-weights/index.mdx
@@ -24,11 +24,12 @@ category: weights
     {
       title: 'Overview',
       description: `This guide builds on the [Add benchmarking to your pallet](/how-to-guides/v3/weights/add-benchmarking)
-        guide. Here, you'll learn how to use the weights in your pallet from the output of benchmarking your pallet's extrinsics.
+        guide. Here, you'll learn how to use the weights in your pallet from the output of
+        benchmarking your pallet's extrinsics.
         (Read more about
         [weights](/v3/concepts/weight) and how it is [related to transaction fees](/v3/runtime/weights-and-fees).)
-        It assumes that you have a file in your pallet's directory called \`weights.rs\`, containing the auto generated 
-        weights from running FRAME's benchmarking tool.`,
+        It assumes that you have a file in your pallet's directory called \`weights.rs\`,
+        containing the auto generated weights from running FRAME's benchmarking tool.`,
     },
   ]}
 />

--- a/v3/how-to-guides/05-storage-migrations/a-nicks-migration/index.mdx
+++ b/v3/how-to-guides/05-storage-migrations/a-nicks-migration/index.mdx
@@ -24,9 +24,10 @@ category: storage migrations
     {
       title: 'Overview',
       description: `This guide will step through a storage migration on [FRAME's Nick's pallet](https://github.com/paritytech/substrate/tree/master/frame/nicks). 
-        It shows how to modify a storage map to provide an optional field that includes a last name, and how to write the migration function ready 
-        to be triggered upon a runtime upgrade. This guide can equally be used in other contexts which require a simple storage migration that 
-        modifies a storage map in a runtime.
+        It shows how to modify a storage map to provide an optional field that includes a
+        last name, and how to write the migration function ready to be triggered upon a
+        runtime upgrade. This guide can equally be used in other contexts which require
+        a simple storage migration that modifies a storage map in a runtime.
         `,
     },
   ]}

--- a/v3/how-to-guides/05-storage-migrations/b-steps-with-polkadotjs-apps/index.mdx
+++ b/v3/how-to-guides/05-storage-migrations/b-steps-with-polkadotjs-apps/index.mdx
@@ -22,8 +22,10 @@ category: storage migrations
     },
     {
       title: 'Overview',
-      description: `This simple guide presents the steps for triggering a runtime migration using [Polkadot-JS Apps\(https://polkadot.js.org/apps/).
-        It assumes that migration code is already written and that the new runtime has already been compiled.
+      description: `This simple guide presents the steps for triggering a runtime migration
+        using [Polkadot-JS Apps\(https://polkadot.js.org/apps/).
+        It assumes that migration code is already written and that the new runtime has already
+        been compiled.
         `,
     },
   ]}

--- a/v3/how-to-guides/05-storage-migrations/c-migration-tests/index.mdx
+++ b/v3/how-to-guides/05-storage-migrations/c-migration-tests/index.mdx
@@ -22,9 +22,10 @@ category: storage migrations
     },
     {
       title: 'Overview',
-      description: `When writing a runtime migration module it is important to test it to avoid any critical issues caused by mangling storage items. This
-		guide provides a walk through of the tests to include for a simple storage migration of a single pallet, using the Nicks pallet
-		migration from the [basic storage migration guide](/how-to-guides/v3/storage-migrations/basics) as a reference.
+      description: `When writing a runtime migration module it is important to test it to avoid
+        any critical issues caused by mangling storage items. This guide provides a walk through
+        of the tests to include for a simple storage migration of a single pallet, using the
+        Nicks pallet migration from the [basic storage migration guide](/how-to-guides/v3/storage-migrations/basics) as a reference.
         `,
     },
   ]}

--- a/v3/how-to-guides/06-consensus/a-pow/index.mdx
+++ b/v3/how-to-guides/06-consensus/a-pow/index.mdx
@@ -25,10 +25,10 @@ category: consensus
     },
     {
       title: 'Overview',
-      description: `The basic-pow node demonstrates how to wire up a custom consensus engine into the Substrate Service. 
-        It uses a minimal proof of work consensus engine to reach agreement over the blockchain. This guide will 
-        teach us many useful aspects of dealing with consensus and prepare us to understand more advanced consensus 
-        engines in the future.
+      description: `The basic-pow node demonstrates how to wire up a custom consensus engine
+        into the Substrate Service. It uses a minimal proof of work consensus engine to reach
+        agreement over the blockchain. This guide will teach us many useful aspects of dealing
+        with consensus and prepare us to understand more advanced consensus engines in the future.
         `,
     },
   ]}

--- a/v3/how-to-guides/07-parachains/a-connect-relay/index.mdx
+++ b/v3/how-to-guides/07-parachains/a-connect-relay/index.mdx
@@ -35,9 +35,13 @@ keywords:
     {
       title: 'Overview',
       description: `
-  Launching a parachain requires a series of steps to ensure that the relay chain knows exactly what the parachain's runtime logic is once a slot on the relay chain is secured.
-  In order to achieve this, you will need to have previously successfully generated a **para ID, genesis state and Wasm runtime blob**.
-  After successfully registering your parachain, you will be able to obtain a parachain slot (in testing though \`sudo\`, and in production via auctions and crowdloans) and start producing blocks.
+  Launching a parachain requires a series of steps to ensure that the relay chain knows
+  exactly what the parachain's runtime logic is once a slot on the relay chain is secured.
+  In order to achieve this, you will need to have previously successfully generated a
+  **para ID, genesis state and Wasm runtime blob**.
+  After successfully registering your parachain, you will be able to obtain a parachain slot
+  (in testing though \`sudo\`, and in production via auctions and crowdloans) and start
+  producing blocks.
       `,
     },
   ]}

--- a/v3/how-to-guides/07-parachains/a-solo-to-parachain/index.mdx
+++ b/v3/how-to-guides/07-parachains/a-solo-to-parachain/index.mdx
@@ -35,10 +35,11 @@ keywords:
     {
       title: 'Overview',
       description: `
-        Integration of Cumulus for any Substrate chain enables this chain to couple it's _finality_ with a
-        relay chain, like Polkadot. This guide does _not_ inform on how to migrate a _running solo-chain_,
-        only the steps required to convert the _codebase_ of a node to use Cumulus for consensus instead
-        of something like GRANDPA that is common for other Substrate solo-chains.
+        Integration of Cumulus for any Substrate chain enables this chain to couple it's
+        _finality_ with a relay chain, like Polkadot. This guide does _not_ inform on how
+        to migrate a _running solo-chain_, only the steps required to convert the _codebase_
+        of a node to use Cumulus for consensus instead of something like GRANDPA that is
+        common for other Substrate solo-chains.
       `,
     },
   ]}

--- a/v3/how-to-guides/07-parachains/c-pre-launch/index.mdx
+++ b/v3/how-to-guides/07-parachains/c-pre-launch/index.mdx
@@ -31,7 +31,10 @@ keywords:
     {
       title: 'Overview',
       description:
-        "The runtime constraints on a parachain are much stricter than a solochain, as you must coordinate with the relay chain to finalize state transitions. When launching a parachain to production, it is critically important to make sure a chain's runtime is properly configured and tested.",
+        `The runtime constraints on a parachain are much stricter than a solochain, as you
+        must coordinate with the relay chain to finalize state transitions. When launching
+        a parachain to production, it is critically important to make sure a chain's runtime
+        is properly configured and tested.`,
     },
   ]}
 />

--- a/v3/how-to-guides/08-tools/a-integrate-try-runtime/index.mdx
+++ b/v3/how-to-guides/08-tools/a-integrate-try-runtime/index.mdx
@@ -24,8 +24,9 @@ category: tools
     {
       title: 'Overview',
       description: `
-The \`try-runtime\` tool is useful for running tests before launching a runtime to production. This is a simple guide 
-which steps through which dependencies to include and where to include them in order to use it inside a runtime. 
+The \`try-runtime\` tool is useful for running tests before launching a runtime to
+production. This is a simple guide which steps through which dependencies to include
+and where to include them in order to use it inside a runtime. 
 `,
     },
   ]}

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -488,7 +488,7 @@ Let's start Charlie's node,
 After it was started, you should see there are **no connected peers** for this node.
 This is because we are trying to connect to a permissioned network, you need to
 get authorization to to be connectable! Alice and Bob were configured already in
-the genesis `chain_spec.rs`, where all others mut be added manually via extrinsic.
+the genesis `chain_spec.rs`, where all others must be added manually via extrinsic.
 
 Remember that we are using `sudo` pallet for our governance, we can make a sudo call
 on `add_well_known_node` dispatch call provided by node-authorization pallet to add
@@ -497,7 +497,7 @@ our node. You can find more avaliable calls in this
 
 Go to **Developer** page, **Sudo** tab, in apps and submit the `nodeAuthorization` -
 `add_well_known_node` call with the peer id in hex of Charlie's node and the
-owner is Charlie, of course. Note Allice is the valid sudo origin for this call.
+owner is Charlie, of course. Note Alice is the valid sudo origin for this call.
 
 ![add_well_known_node](../../../src/images/tutorials/03-permissioned-network/add_well_known_node.png)
 
@@ -510,10 +510,8 @@ by default in a local network.
 <Message
   type={`gray`}
   title={`Note`}
-  text="If your nodes are not on the same local network, you don't need mDNS and should use
-    `--no-mdns` to disable it. If running node in a public internet, you need to use
-    `--no-mdns` to disable it. If running node in a public internet, you need to use
-    Otherwise put the reachable nodes as bootnodes of Chain Spec.
+  text="If your nodes are not on the same local network, you don't need mDNS and should use    `--no-mdns` to disable it.
+  If running node in a public internet, you may wish to specify bootnodes if a static IP or DNS entry is available in the Chain Spec, for convenience.
     "
 />
 
@@ -523,7 +521,7 @@ Now we have 3 well known nodes all validating blocks together!
 
 Let's add Dave's node, not as a well-known node, but a "sub-node" of Charlie.
 Dave will _only_ be able to connect to Charlie to access the network.
-This is a security feature: as Charlie is therefor solely responsible for any
+This is a security feature: as Charlie is therefore solely responsible for any
 connected sub-node peer. There is one point of access control for David in case
 they need to be removed or audited.
 


### PR DESCRIPTION
On my mac laptop/firefox the descriptions were not wrapping themselves (I think they're rendered preformatted) and thus you had to scroll right to read what they were saying. It should be easier to see everything without having to scroll right now.

*No changes to any text.*