### PR TITLE
fix storage getter name

### DIFF
--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -384,7 +384,7 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn all_kitties_count)]
+	#[pallet::getter(fn kitty_cnt)]
 	pub(super) type KittyCnt<T: Config> = StorageValue<_, u64, ValueQuery>;
 
 	// ACTION #7: Remaining storage items.


### PR DESCRIPTION
In the rest of the tutorial the getter `all_kitties_count` is not used