### PR TITLE
Tut5: node-template key insert added mandatory --scheme

### DIFF
--- a/v3/tutorials/05-private-network/index.mdx
+++ b/v3/tutorials/05-private-network/index.mdx
@@ -534,7 +534,7 @@ Because the Rust compiler produces optimized WebAssembly binaries that aren't de
 To ensure determinism, all participants in the blockchain network must use exactly the same raw chain specification file.
 For more information about this issue, see [Hunting down a non-determinism-bug in our Rust Wasm build](https://dev.to/gnunicorn/hunting-down-a-non-determinism-bug-in-our-rust-wasm-build-4fk1).
 
-## Launch the private network
+## Launch the private networkn
 
 After you distribute the custom chain specification to all network participants, you're ready to launch your own private blockchain.
 The steps are similar to the steps you followed in [Start the blockchain using predefined accounts](#Start-the-blockchain-using-predefined-accounts).
@@ -649,6 +649,7 @@ To insert keys into the keystore:
    ```bash
    ./target/release/node-template key insert --base-path /tmp/node01 \
    --chain customSpecRaw.json \
+   --scheme Sr25519
    --suri <your-secret-seed> \
    --password-interactive \
    --key-type aura
@@ -673,6 +674,7 @@ To insert keys into the keystore:
    ```bash
    ./target/release/node-template key insert --base-path /tmp/node01 \
    --chain customSpecRaw.json \
+   --scheme Ed25519
    --suri <your-secret-key> \
    --password-interactive \
    --key-type gran

--- a/v3/tutorials/05-private-network/index.mdx
+++ b/v3/tutorials/05-private-network/index.mdx
@@ -534,7 +534,7 @@ Because the Rust compiler produces optimized WebAssembly binaries that aren't de
 To ensure determinism, all participants in the blockchain network must use exactly the same raw chain specification file.
 For more information about this issue, see [Hunting down a non-determinism-bug in our Rust Wasm build](https://dev.to/gnunicorn/hunting-down-a-non-determinism-bug-in-our-rust-wasm-build-4fk1).
 
-## Launch the private networkn
+## Launch the private network
 
 After you distribute the custom chain specification to all network participants, you're ready to launch your own private blockchain.
 The steps are similar to the steps you followed in [Start the blockchain using predefined accounts](#Start-the-blockchain-using-predefined-accounts).


### PR DESCRIPTION

Trying to execute as written without scheme provided leads to

substrate-node-template git:(tut5) ✗ ./target/release/node-template key insert --base-path /tmp/node01 \
--chain customSpecRaw.json \
--suri 0xSOMEKEY \
--password-interactive \
--key-type aura
error: The following required arguments were not provided:
--scheme <SCHEME>

USAGE:
node-template key insert --base-path <PATH> --chain <CHAIN_SPEC> --key-type <key-type> --password-interactive --scheme <SCHEME> --suri <suri> --tracing-receiver <RECEIVER>

For more information try --help