### PR TITLE
[docs] fix typo in commands (tutorials/05-private-network)

### DIFF
--- a/v3/tutorials/05-private-network/index.mdx
+++ b/v3/tutorials/05-private-network/index.mdx
@@ -649,7 +649,7 @@ To insert keys into the keystore:
    ```bash
    ./target/release/node-template key insert --base-path /tmp/node01 \
    --chain customSpecRaw.json \
-   --scheme Sr25519
+   --scheme Sr25519 \
    --suri <your-secret-seed> \
    --password-interactive \
    --key-type aura
@@ -674,7 +674,7 @@ To insert keys into the keystore:
    ```bash
    ./target/release/node-template key insert --base-path /tmp/node01 \
    --chain customSpecRaw.json \
-   --scheme Ed25519
+   --scheme Ed25519 \
    --suri <your-secret-key> \
    --password-interactive \
    --key-type gran


### PR DESCRIPTION
The command could not be executed, so I fixed it.