### PR TITLE
Fix error in example code of runtime storage documentation

### DIFF
--- a/v3/docs/03-runtime/e-storage/index.mdx
+++ b/v3/docs/03-runtime/e-storage/index.mdx
@@ -125,18 +125,18 @@ type SomePrivateValue<T> = StorageValue<_, u32, ValueQuery>;
 pub(super) type SomePrimitiveValue<T> = StorageValue<_, u32, ValueQuery>;
 
 #[pallet::storage]
-pub(super) type SomeComplexValue<T> = StorageValue<_, T::AccountId, ValueQuery>;
+pub(super) type SomeComplexValue<T: Config> = StorageValue<_, T::AccountId, ValueQuery>;
 
 #[pallet::storage]
 #[pallet::getter(fn some_map)]
-pub(super) type SomeMap<T> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
+pub(super) type SomeMap<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
 
 #[pallet::storage]
-pub(super) type SomeDoubleMap<T> = StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
+pub(super) type SomeDoubleMap<T: Config> = StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
 
 #[pallet::storage]
 #[pallet::getter(fn some_nmap)]
-pub(super) type SomeNMap<T> = StorageNMap<
+pub(super) type SomeNMap<T: Config> = StorageNMap<
     _,
     (
         NMapKey<Blake2_128Concat, u32>,


### PR DESCRIPTION
In the given example, generic parameter was specified without restricting but later on uses type parameter of that generic. This have generated error regarding associated type not found. Restricting this generic type however resolved the error.