### PR TITLE
Fix #747: [kitties-tutorial] File not found for module mock and tests

### DIFF
--- a/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
+++ b/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
@@ -2,9 +2,6 @@
 
 pub use pallet::*;
 
-mod mock;
-mod tests;
-
 #[frame_support::pallet]
 pub mod pallet {
   use frame_support::pallet_prelude::*;


### PR DESCRIPTION
After I removed these two lines, the build succeeded.