### PR TITLE
Fix Ubuntu install command (tutorial)

### DIFF
--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -27,7 +27,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev
+sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
 ```
 
 ### Arch Linux


### PR DESCRIPTION
The command in the tutorial doesn't match the one in the actual setup docs: https://github.com/substrate-developer-hub/substrate-node-template/blob/main/docs/rust-setup.md . Leads to all sorts of install/compilation errors