### PR TITLE
[Tutorial: permissioned-network] Fix #760 Add 0x prefix to the hexadecimal peer ID

### DIFF
--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -341,7 +341,7 @@ c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
 12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2
 
 # BS58 decoded Peer ID in hex:
-0024080112201ce5f00ef6e89374afb625f1ae4c1546d31234e87e3c3f51a62b91dd6bfa57df
+0x0024080112201ce5f00ef6e89374afb625f1ae4c1546d31234e87e3c3f51a62b91dd6bfa57df
 ```
 
 For Bob's _well known_ node:
@@ -354,7 +354,7 @@ For Bob's _well known_ node:
 12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust
 
 # BS58 decoded Peer ID in hex:
-002408011220dacde7714d8551f674b8bb4b54239383c76a2b286fa436e93b2b7eb226bf4de7
+0x002408011220dacde7714d8551f674b8bb4b54239383c76a2b286fa436e93b2b7eb226bf4de7
 ```
 
 For Charlie's _NOT well known_ node:
@@ -367,7 +367,7 @@ For Charlie's _NOT well known_ node:
 12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ
 
 # BS58 decoded Peer ID in hex:
-002408011220876a7b4984f98006dc8d666e28b60de307309835d775e7755cc770328cdacf2e
+0x002408011220876a7b4984f98006dc8d666e28b60de307309835d775e7755cc770328cdacf2e
 ```
 
 For Dave's _sub-node_ (to Charlie, [more below](#add-dave-as-a-sub-node-to-charlie)):
@@ -380,7 +380,7 @@ a99331ff4f0e0a0434a6263da0a5823ea3afcfffe590c9f3014e6cf620f2b19a
 12D3KooWPHWFrfaJzxPnqnAYAoRUyAHHKqACmEycGTVmeVhQYuZN
 
 # BS58 decoded Peer ID in hex:
-002408011220c81bc1d7057a1511eb9496f056f6f53cdfe0e14c8bd5ffca47c70a8d76c1326d
+0x002408011220c81bc1d7057a1511eb9496f056f6f53cdfe0e14c8bd5ffca47c70a8d76c1326d
 ```
 
 The nodes of Alice and Bob are already configured in genesis storage and serve as

--- a/v3/tutorials/05-private-network/index.mdx
+++ b/v3/tutorials/05-private-network/index.mdx
@@ -349,12 +349,10 @@ To generate keys using the node template:
 1. Use the **secret seed** for the account you just generated to derive keys using the Ed25519 signature scheme by running the following command:
 
    ```bash
-   ./target/release/node-template key inspect --password-interactive --scheme Ed25519 0x0087016ebbdcf03d1b7b2ad9a958e14a43f2351cd42f2f0a973771b90fb0112f
+   ./target/release/node-template key inspect --scheme Ed25519 0x0087016ebbdcf03d1b7b2ad9a958e14a43f2351cd42f2f0a973771b90fb0112f
    ```
 
-1. Type the password you used to the generated keys.
-
-   The command displays output similar to the following:
+1. The command displays output similar to the following:
 
    ```bash
    Secret Key URI `0x0087016ebbdcf03d1b7b2ad9a958e14a43f2351cd42f2f0a973771b90fb0112f` is account:

--- a/v3/tutorials/05-private-network/index.mdx
+++ b/v3/tutorials/05-private-network/index.mdx
@@ -349,10 +349,12 @@ To generate keys using the node template:
 1. Use the **secret seed** for the account you just generated to derive keys using the Ed25519 signature scheme by running the following command:
 
    ```bash
-   ./target/release/node-template key inspect --scheme Ed25519 0x0087016ebbdcf03d1b7b2ad9a958e14a43f2351cd42f2f0a973771b90fb0112f
+   ./target/release/node-template key inspect --password-interactive --scheme Ed25519 0x0087016ebbdcf03d1b7b2ad9a958e14a43f2351cd42f2f0a973771b90fb0112f
    ```
 
-1. The command displays output similar to the following:
+1. Type the password you used to the generated keys.
+
+   The command displays output similar to the following:
 
    ```bash
    Secret Key URI `0x0087016ebbdcf03d1b7b2ad9a958e14a43f2351cd42f2f0a973771b90fb0112f` is account:


### PR DESCRIPTION
https://docs.substrate.io/tutorials/v3/permissioned-network/#obtaining-node-keys-and-peerids

Add 0x prefix to the hexadecimal peer ID