### PR TITLE
Fix the nicks pallet dependency issue in the "Add a Pallet" tutorial

### DIFF
--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -81,7 +81,7 @@ To add the Nicks pallet to the Substrate node template:
    [dependencies.pallet-nicks]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'devhub/latest'
+   tag = 'monthly-2021-12'
    version = '4.0.0-dev'
    ```
 


### PR DESCRIPTION
Nicks pallet dependency with the tag `monthly-2021-12` fixes the node template build. `cargo check -p node-template-runtime` completes successfully.  Related to #765.