### PR TITLE
Lg/windows wsl

### DIFF
--- a/content/config/nav.yaml
+++ b/content/config/nav.yaml
@@ -42,7 +42,7 @@ docs:
     - title: Install
       url: main-docs/install/
       pages:
-        - title: Rust compiler and toolchain
+        - title: Rust toolchain
           url: /main-docs/install/rust-builds/
         - title: Linux
           url: /main-docs/install/linux/

--- a/content/md/en/docs/main-docs/install/index.md
+++ b/content/md/en/docs/main-docs/install/index.md
@@ -1,4 +1,8 @@
-# Install
+---
+title: Install
+description:
+keywords:
+---
 
 Before you can start developing a Substrate-based blockchain, you need to prepare your development environment with the required compiler and tools.
 Because Substrate—and most of the developer tools for working with Substrate—are written in the [Rust](https://www.rust-lang.org/) programming language, the first step in preparing your computer is to install Rust.

--- a/content/md/en/docs/main-docs/install/linux.md
+++ b/content/md/en/docs/main-docs/install/linux.md
@@ -33,7 +33,7 @@ To install the Rust toolchain on Linux:
 
 1. Add any package dependencies you are missing to your local development environment by running an appropriate package management command for your Linux distribution.
     
-    For example, on Ubuntu Desktop, you might run a command similar to the following:
+    For example, on Ubuntu Desktop or Ubuntu Server, you might run a command similar to the following:
     
     ```bash
     sudo apt install --assume-yes git clang curl libssl-dev
@@ -141,3 +141,25 @@ To compile the Substrate node template:
     Because of the number of packages required, compiling the node can take several minutes.
 
 After the build completes successfully, your local computer is ready for Substrate development activity.
+
+## Where to go next
+
+The Substrate Developer Hub acts as a central portal for access to the many resources available to the community.
+Depending on your interests and learning style, you might prefer one avenue over another.
+For example, if you prefer to read source code and are familiar with Rust, you might want to start by digging into the [Rust API](reference/rust-docs/).
+If you are new to Substrate and the Substrate ecosystem, you might want broader exposure to what resources are available and where to find them by checking out [Explore](/main-docs/explore/).
+
+Here are a few additional suggestions for where you can learn more.
+
+#### Tell me
+
+* [Node architecture](main-docs/node-architecture/)
+* [Design runtime logic](/main-docs/design/)
+Network topologies
+* [Build process](main-docs/build/)
+
+#### Guide me
+
+* [Build a local blockchain](/tutorials/get-started/build-local-blockchain/)
+* [Simulate a network](/tutorials/get-started/simulate-network/)
+* [Start a trusted validator network](/tutorials/get-started/trusted-network/)

--- a/content/md/en/docs/main-docs/install/linux.md
+++ b/content/md/en/docs/main-docs/install/linux.md
@@ -33,11 +33,15 @@ To install the Rust toolchain on Linux:
 
 1. Add any package dependencies you are missing to your local development environment by running an appropriate package management command for your Linux distribution.
     
-    For example, on Ubuntu, you might run a command similar to the following:
+    For example, on Ubuntu Desktop, you might run a command similar to the following:
     
     ```bash
     sudo apt install --assume-yes git clang curl libssl-dev
     ```
+
+    Remember that different distributions might use different package managers and bundle packages in different ways. 
+    For example, depending on your installation selections, Ubuntu Desktop and Ubuntu Server might have different packages and different requirements.
+    However, the four packages listed in this command-line example are applicable for many common Linux distributions, including Debian, Linux Mint, MX Linux, and Elementary OS.
 
 1. Download the `rustup` installation program and use it to install Rust by running the following command:
     
@@ -124,6 +128,9 @@ To compile the Substrate node template:
     ```bash
     git checkout latest
     ```
+
+    This command checks out the repository in a detached state.
+    If you want to save your changes, you can create a branch from this state.
 
 1. Compile the node template by running the following command:
     

--- a/content/md/en/docs/main-docs/install/linux.md
+++ b/content/md/en/docs/main-docs/install/linux.md
@@ -1,4 +1,8 @@
-# Linux development environment
+---
+title: Linux development environment
+description: Set up a local development environment for Substrate on Linux.
+keywords:
+---
 
 Rust supports most Linux distributions.
 Depending on the specific distribution and version of the operating system you use, you might need to add some package dependencies to your environment.

--- a/content/md/en/docs/main-docs/install/macos.md
+++ b/content/md/en/docs/main-docs/install/macos.md
@@ -155,6 +155,9 @@ To compile the Substrate node template:
     git checkout latest
     ```
 
+    This command checks out the repository in a detached state.
+    If you want to save your changes, you can create a branch from this state.
+
 1. Compile the node template by running the following command:
     
     ```bash

--- a/content/md/en/docs/main-docs/install/macos.md
+++ b/content/md/en/docs/main-docs/install/macos.md
@@ -1,4 +1,8 @@
-# macOS development environment
+---
+title: macOS development environment
+description: et up a local development environment for Substrate on macOS.
+keywords:
+---
 
 You can install Rust and set up a Substrate development environment on Apple macOS computers with either Intel or an Apple M1 processors.
 

--- a/content/md/en/docs/main-docs/install/macos.md
+++ b/content/md/en/docs/main-docs/install/macos.md
@@ -167,3 +167,25 @@ To compile the Substrate node template:
     Because of the number of packages required, compiling the node can take several minutes.
 
 After the build completes successfully, your local computer is ready for Substrate development activity.
+
+## Where to go next
+
+The Substrate Developer Hub acts as a central portal for access to the many resources available to the community.
+Depending on your interests and learning style, you might prefer one avenue over another.
+For example, if you prefer to read source code and are familiar with Rust, you might want to start by digging into the [Rust API](reference/rust-docs/).
+If you are new to Substrate and the Substrate ecosystem, you might want broader exposure to what resources are available and where to find them by checking out [Explore](/main-docs/explore/).
+
+Here are a few additional suggestions for where you can learn more.
+
+#### Tell me
+
+* [Node architecture](main-docs/node-architecture/)
+* [Design runtime logic](/main-docs/design/)
+Network topologies
+* [Build process](main-docs/build/)
+
+#### Guide me
+
+* [Build a local blockchain](/tutorials/get-started/build-local-blockchain/)
+* [Simulate a network](/tutorials/get-started/simulate-network/)
+* [Start a trusted validator network](/tutorials/get-started/trusted-network/)

--- a/content/md/en/docs/main-docs/install/other-tools.md
+++ b/content/md/en/docs/main-docs/install/other-tools.md
@@ -1,4 +1,8 @@
-# Developer tools
+---
+title: Developer tools
+description:
+keywords:
+---
 
 The Substrate node template includes a core set of features and tools for runtime development. 
 However, there are also many other specialized tools available that you can install to complement and extend your development environment or to handle specific tasks.

--- a/content/md/en/docs/main-docs/install/rust-builds.md
+++ b/content/md/en/docs/main-docs/install/rust-builds.md
@@ -1,14 +1,22 @@
-<!-- TODO Manage expectations about build times on lower-spec hardware. Define that practical dev environment requirements are higher than just for running a node  -->
+---
+title: Rust toolchain
+description:
+keywords:
+---
 
-# Rust compiler and toolchain
+<!-- TODO Manage expectations about build times on lower-spec hardware. Define that practical dev environment requirements are higher than just for running a node  -->
 
 Rust is a modern, type sound, and performant programming language that provides a rich feature set for building complex systems.
 The language also has an active developer community and a growing ecosystem of sharable libraries called **crates**.
+
+## Learning Rust
 
 Rust is the core language used to build Substrate-based blockchains, so if you intend to do Substrate development, you need to be familiar with the Rust programming language, compiler, and toolchain management.
 
 If you are just getting started with Rust, you should bookmark [The Rust Programming Language](https://doc.rust-lang.org/book/) and refer to other [Learn Rust](https://www.rust-lang.org/learn) resources on the Rust website to guide you.
 However, there are a few important points to be aware of as you prepare your development environment.
+
+## About the Rust toolchain
 
 The core tools in the Rust **toolchain** are the `rustc` compiler, the `cargo` build and package manager, and the `rustup` toolchain manager.
 At any given point in time, there can multiple versions of Rust available. 

--- a/content/md/en/docs/main-docs/install/troubleshooting.md
+++ b/content/md/en/docs/main-docs/install/troubleshooting.md
@@ -1,4 +1,8 @@
-# Troubleshoot Rust issues
+---
+title: Troubleshoot Rust issues
+description:
+keywords:
+---
 
 If compiling the [Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template) fails, the problem is most likely to be caused by how Rust is configured in your development environment.
 This section suggests how you can diagnose and fix configuration issues.

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -1,4 +1,8 @@
-# Windows development environment
+---
+title: Windows development environment
+description: Set up a local development environment for Substrate on Windows.
+keywords:
+---
 
 In general, UNIX-based operating systems—like macOS or Linux—provide a better development environment for building Substrate-based blockchains.
 All of the code examples and command-line instructions in Substrate [Tutorials](../tutorials) and [How-to guides](../reference/how-to-guides) illustrate how to interact with Substrate using UNIX-compatible commands in a terminal.

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -49,7 +49,7 @@ To prepare a development environment using Windows Subsystem for Linux:
 
 1. After the distribution is downloaded, close the terminal.
 
-1. Click the Start menu, select Shut down or sign out, then click **Restart** to restart the computer.
+1. Click the Start menu, select **Shut down or sign out**, then click **Restart** to restart the computer.
    
    Restarting the computer is required to start the installation of the Linux distribution.
    It can take a few minutes for the installation to complete after you restart.

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -74,7 +74,7 @@ To install the Rust toolchain on WSL:
 1. Add the required packages for the Ubuntu distribution by running the following command:
    
    ```
-   sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev
+   sudo apt install --assume-yes git clang curl libssl-dev
    ```
 
 1. Download the `rustup` installation program and use it to install Rust for the Ubuntu distribution by running the following command:

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -29,6 +29,7 @@ To prepare a development environment using Windows Subsystem for Linux:
    If you have Microsoft Windows 10, version 2004 (Build 19041 and higher), or Microsoft Windows 11, Windows Subsystem for Linux is available by default and you can continue to the next step.
 
    If you have an older version of Microsoft Windows installed, see [WSL manual installation steps for older versions](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
+   If you are installing on an older version of Microsoft Windows, you can download and install WLS 2 if your computer has Windows 10, version 1903 or higher.
 
 1. Select Windows PowerShell or Command Prompt from the Start menu, right-click, then **Run as administrator**.
 

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -121,7 +121,20 @@ To install the Rust toolchain on WSL:
     The command displays output similar to the following:
 
     <pre>
-
+    Default host: x86_64-unknown-linux-gnu
+    rustup home:  /home/subdocs/.rustup
+    
+    installed toolchains
+    --------------------
+    
+    stable-x86_64-unknown-linux-gnu (default)
+    nightly-x86_64-unknown-linux-gnu
+    
+    active toolchain
+    ----------------
+    
+    stable-x86_64-unknown-linux-gnu (default)
+    rustc 1.58.1 (db9d1b20b 2022-01-20)
     </pre>
 
 ## Compile a Substrate node

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -176,3 +176,25 @@ To compile the Substrate node template:
     Because of the number of packages required, compiling the node can take several minutes.
 
 After the build completes successfully, your local computer is ready for Substrate development activity.
+
+## Where to go next
+
+The Substrate Developer Hub acts as a central portal for access to the many resources available to the community.
+Depending on your interests and learning style, you might prefer one avenue over another.
+For example, if you prefer to read source code and are familiar with Rust, you might want to start by digging into the [Rust API](reference/rust-docs/).
+If you are new to Substrate and the Substrate ecosystem, you might want broader exposure to what resources are available and where to find them by checking out [Explore](/main-docs/explore/).
+
+Here are a few additional suggestions for where you can learn more.
+
+#### Tell me
+
+* [Node architecture](main-docs/node-architecture/)
+* [Design runtime logic](/main-docs/design/)
+Network topologies
+* [Build process](main-docs/build/)
+
+#### Guide me
+
+* [Build a local blockchain](/tutorials/get-started/build-local-blockchain/)
+* [Simulate a network](/tutorials/get-started/simulate-network/)
+* [Start a trusted validator network](/tutorials/get-started/trusted-network/)

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -4,7 +4,7 @@ In general, UNIX-based operating systems—like macOS or Linux—provide a bette
 All of the code examples and command-line instructions in Substrate [Tutorials](../tutorials) and [How-to guides](../reference/how-to-guides) illustrate how to interact with Substrate using UNIX-compatible commands in a terminal.
 
 However, if your local computer uses Microsoft Windows instead of a UNIX-based operating system, you can configure it with additional packages to make it a suitable development environment for building Substrate-based blockchains.
-To prepare a development environment on a computer running Microsoft Windows, you can use Windows Subsystem for Linux (WSL) to emulate a UNIX operating environment (recommended).
+To prepare a development environment on a computer running Microsoft Windows, you can use Windows Subsystem for Linux (WSL) to emulate a UNIX operating environment.
 
 ## Before you begin
 
@@ -13,59 +13,89 @@ Before installing on Microsoft Windows, verify the following basic requirements:
 * You have a computer running a supported version of the Microsoft Windows operating system.
 * You must be running Microsoft Windows 10, version 2004 or later, or Microsoft Windows 11 to install Windows Subsystem for Linux on a computer with the Windows desktop operating system.
 * You must be running Microsoft Windows Server 2019, or later, to install Windows Subsystem for Linux on a computer with the Windows server operating system.
+* You have good internet connection and access to a shell terminal on your local computer.
 
-## Set up Windows Subsystem for Linux development environment
+## Set up Windows Subsystem for Linux
 
 Windows Subsystem for Linux (WSL) enables you to emulate a Linux environment on a computer that uses the Windows operating system. 
 The primary advantage of this approach for Substrate development is that you can use all of the code and command-line examples as described in the Substrate documentation. 
-You can run common commands—such as `ls` and `ps`—unmodified.
+For example, you can run common commands—such as `ls` and `ps`—unmodified.
 By using Windows Subsystem for Linux, you can avoid configuring a virtual machine image or a dual-boot operating system.
 
 To prepare a development environment using Windows Subsystem for Linux:
 
 1. Check your Windows version and build number to see if Windows Subsystem for Linux is enabled by default.
    
-   If you have Microsoft Windows 10, version 2004 (Build 19041 and higher), or Microsoft Windows 11, Windows Subsystem for Linux is enabled by default and you can continue to the next step.
+   If you have Microsoft Windows 10, version 2004 (Build 19041 and higher), or Microsoft Windows 11, Windows Subsystem for Linux is available by default and you can continue to the next step.
 
-   If you have an older version of Microsoft Windows installed, see [WSL manual installation steps for older versions](https://docs.microsoft.com/en-us/windows/wsl/install-manual). 
+   If you have an older version of Microsoft Windows installed, see [WSL manual installation steps for older versions](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
 
-1. Open PowerShell or Windows Command Prompt, then run the following command:
+1. Select Windows PowerShell or Command Prompt from the Start menu, right-click, then **Run as administrator**.
+
+1. In the PowerShell or Command Prompt terminal, run the following command:
    
    ```
    wsl --install
    ```
 
-   This command enables required components, downloads the latest Linux kernel, and installs the Ubuntu Linux distribution.
+   This command enables the required WSL 2 components that are part of the Windows operating system, downloads the latest Linux kernel, and installs the Ubuntu Linux distribution by default.
 
-1. Restart the computer.
+   If you want to review the other Linux distributions available, run the following command:
 
-1. Open the Ubuntu distribution from the Start menu, then set up your user account and password.
+   ```
+   wsl --list --online
+   ```
+
+1. After the distribution is downloaded, close the terminal.
+
+1. Click the Start menu, select Shut down or sign out, then click **Restart** to restart the computer.
    
+   Restarting the computer is required to start the installation of the Linux distribution.
+   It can take a few minutes for the installation to complete after you restart.
+
    For more information about setting up WSL as a development environment, see [Set up a WSL development environment](https://docs.microsoft.com/en-us/windows/wsl/setup/environment).
 
-1. Use the Ubuntu Advanced Packaging Tool (`apt`) to get the latest updates for the Ubuntu distribution:
+## Install required packages and Rust
+
+To install the Rust toolchain on WSL:
+
+1. Click the Start menu, then select **Ubuntu**.
+
+1. Type a UNIX user name to create user account.
+
+1. Type a password for your UNIX user, then retype the password to confirm it.
+
+1. Download the latest updates for the Ubuntu distribution using the Ubuntu Advanced Packaging Tool (`apt`) by running the following command:
    
    ```
    sudo apt update
    ```
 
-1. Use the Ubuntu Advanced Packaging Tool (`apt`) to install required packages:
+1. Add the required packages for the Ubuntu distribution by running the following command:
    
    ```
-   sudo apt install -y git clang curl libssl-dev llvm libudev-dev
+   sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev
    ```
 
-1. Install `rustup` for the Ubuntu distribution by running the following command:
-   
-   ```
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   ```
+1. Download the `rustup` installation program and use it to install Rust for the Ubuntu distribution by running the following command:
+    
+    ```bash
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    ```
 
-1. Update the current shell with configuration settings for Rust by running the following command:
-   
-   ```
-   source ~/.cargo/env
-   ```
+1. Follow the prompts displayed to proceed with a default installation.
+
+1. Update your current shell to include Cargo by running the following command:
+    
+    ```bash
+    source ~/.cargo/env
+    ```
+
+1. Verify your installation by running the following command:
+    
+    ```bash
+    rustc --version
+    ```
 
 1. Configure the Rust toolchain to use the latest stable version as the default toolchain by running the following commands:
    
@@ -74,13 +104,61 @@ To prepare a development environment using Windows Subsystem for Linux:
    rustup update
    ```
 
-1. Add the `nightly` version of the toolchain and the WebAssembly (`wasm`) target for the nightly toolchain by running the following commands:
+1. Add the `nightly` version of the toolchain and the `nightly` WebAssembly (`wasm`) target to your development environment by running the following commands:
    
    ```
    rustup update nightly
    rustup target add wasm32-unknown-unknown --toolchain nightly
    ```
 
-## Verify your installation
+1. Verify the configuration of your development environment by running the following command:
+    
+    ```bash
+    rustup show
+    ```
 
-## Troubleshooting
+    The command displays output similar to the following:
+
+    <pre>
+
+    </pre>
+
+## Compile a Substrate node
+
+Now that you have Rust installed and the Rust toolchains configured for Substrate development, you are ready to finish setting up your development environment by cloning the Substrate **node template** files and compiling a Substrate node.
+
+The node template provides a working environment that includes all of the most common features you need to build a blockchain without any extraneous modules or tools. 
+To ensure that the node template offers a relatively stable working environment for you to experiment with, the recommended best practice is to clone Substrate node template from the Substrate Developer Hub  repository, rather than from the core Substrate repository.
+
+To compile the Substrate node template:
+
+1. Clone the node template repository by running the following command:
+    
+    ```bash
+    git clone https://github.com/substrate-developer-hub/substrate-node-template
+    ```
+
+1. Change to the root of the node template directory by running the following command:
+    
+    ```bash
+    cd substrate-node-template
+    ```
+
+1. Switch to the version of the repository that has the `latest` tag by running the following command:
+    
+    ```bash
+    git checkout latest
+    ```
+
+    This command checks out the repository in a detached state.
+    If you want to save your changes, you can create a branch from this state.
+
+1. Compile the node template by running the following command:
+    
+    ```bash
+    cargo build --release
+    ```
+
+    Because of the number of packages required, compiling the node can take several minutes.
+
+After the build completes successfully, your local computer is ready for Substrate development activity.


### PR DESCRIPTION
Updated with Windows section (removed native Windows setup) and a few other changes.
I might still add Arch and Red Hat examples later on using tabbed code blocks, but for now, most the "top ten" distros in use seem to be Debian > Ubuntu derived.

@shawntabrizi you mentioned something bout setting this up in the right place. I didn't see any options in the install process for controlling that. I was able to compile and start the node in WSL. If you can point me in the right direction for the project setup stuff, I'll look into it.