### PR TITLE
remove reference to develop branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@ guidelines if making any non-trivial PRs here.
 
 - `main` branch is available at: https://docs.substrate.io/
 
-### Staging deployment
-
-- `develop` branch is available at: https://develop--substrate-docs.netlify.app/
-
 ## 🚀 Quick start
 
 1.  **Clone the repo**


### PR DESCRIPTION
develop branch isn't used any more - we can just branch off main like normal now.