### PR TITLE
Update ink! tutorial for `v3.0.0-rc9`

### DIFF
--- a/static/assets/tutorials/ink-workshop/1.1-finished-code.rs
+++ b/static/assets/tutorials/ink-workshop/1.1-finished-code.rs
@@ -13,7 +13,7 @@ mod incrementer {
 		#[ink(constructor)]
 		pub fn new(init_value: i32) -> Self {
 			// Contract Constructor
-			Self{}
+			Self {}
 		}
 
 		#[ink(message)]

--- a/static/assets/tutorials/ink-workshop/1.2-finished-code.rs
+++ b/static/assets/tutorials/ink-workshop/1.2-finished-code.rs
@@ -21,7 +21,7 @@ mod incrementer {
         #[ink(constructor)]
         pub fn default() -> Self {
             Self {
-                value: 0,
+                value: Default::default(),
             }
         }
 

--- a/static/assets/tutorials/ink-workshop/1.3-finished-code.rs
+++ b/static/assets/tutorials/ink-workshop/1.3-finished-code.rs
@@ -15,14 +15,14 @@ mod incrementer {
         #[ink(constructor)]
         pub fn new(init_value: i32) -> Self {
             Self {
-                value: init_value
+                value: init_value,
             }
         }
 
         #[ink(constructor)]
         pub fn default() -> Self {
             Self {
-                value: 0
+                value: Default::default(),
             }
         }
 

--- a/static/assets/tutorials/ink-workshop/1.3-template.rs
+++ b/static/assets/tutorials/ink-workshop/1.3-template.rs
@@ -15,14 +15,14 @@ mod incrementer {
         #[ink(constructor)]
         pub fn new(init_value: i32) -> Self {
             Self {
-                value: init_value
+                value: init_value,
             }
         }
 
         #[ink(constructor)]
         pub fn default() -> Self {
             Self {
-                value: 0
+                value: Default::default(),
             }
         }
 

--- a/static/assets/tutorials/ink-workshop/1.4-finished-code.rs
+++ b/static/assets/tutorials/ink-workshop/1.4-finished-code.rs
@@ -22,7 +22,7 @@ mod incrementer {
         #[ink(constructor)]
         pub fn default() -> Self {
             Self {
-                value: 0,
+                value: Default::default(),
             }
         }
 

--- a/static/assets/tutorials/ink-workshop/1.4-template.rs
+++ b/static/assets/tutorials/ink-workshop/1.4-template.rs
@@ -22,7 +22,7 @@ mod incrementer {
         #[ink(constructor)]
         pub fn default() -> Self {
             Self {
-                value: 0,
+                value: Default::default(),
             }
         }
 

--- a/static/assets/tutorials/ink-workshop/1.5-template.rs
+++ b/static/assets/tutorials/ink-workshop/1.5-template.rs
@@ -5,28 +5,25 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod incrementer {
+    // ACTION: Import the `SpreadAllocate` trait and derive it for your contract
 
     #[ink(storage)]
     pub struct Incrementer {
         value: i32,
-        // ACTION: Add a `HashMap` from `AccountId` to `i32` named `my_value`
+        // ACTION: Add a `Mapping` from `AccountId` to `i32` named `my_value`
     }
 
     impl Incrementer {
         #[ink(constructor)]
         pub fn new(init_value: i32) -> Self {
-            Self {
-				value: init_value,
-				// ACTION: Set initial `my_value`
-            }
+            // ACTION: Use `initialize_contract` to set an initial value
+            // for `value` and `my_value`
         }
 
         #[ink(constructor)]
         pub fn default() -> Self {
-            Self {
-                value: 0,
-				// ACTION: Set initial `my_value`
-            }
+            // ACTION: Use `initialize_contract` to set default values
+            // for `value` and `my_value`
         }
 
         #[ink(message)]
@@ -41,12 +38,8 @@ mod incrementer {
 
         #[ink(message)]
         pub fn get_mine(&self) -> i32 {
-            // ACTION: Get `my_value` using `my_value_or_zero` on `&self.env().caller()`
+            // ACTION: Get `my_value` using `Mapping::get()` on `&self.env().caller()`
             // ACTION: Return `my_value`
-        }
-
-        fn my_value_or_zero(&self, of: &AccountId) -> i32 {
-            // ACTION: `get` and return the value of `of` and `unwrap_or` return 0
         }
     }
 

--- a/static/assets/tutorials/ink-workshop/1.6-template.rs
+++ b/static/assets/tutorials/ink-workshop/1.6-template.rs
@@ -5,27 +5,34 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod incrementer {
+    use ink_storage::traits::SpreadAllocate;
+
     #[ink(storage)]
+    #[derive(SpreadAllocate)]
     pub struct Incrementer {
         value: i32,
-        my_value: ink_storage::collections::HashMap<AccountId, i32>,
+        my_value: ink_storage::Mapping<AccountId, i32>,
     }
 
     impl Incrementer {
         #[ink(constructor)]
         pub fn new(init_value: i32) -> Self {
-            Self {
-                value: init_value,
-                my_value: ink_storage::collections::HashMap::new(),
-            }
+            // This call is required in order to correctly initialize the
+            // `Mapping`s of our contract.
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.value = init_value;
+                let caller = Self::env().caller();
+                contract.my_value.insert(&caller, &0);
+            })
         }
 
         #[ink(constructor)]
         pub fn default() -> Self {
-            Self {
-                value: 0,
-                my_value: Default::default(),
-            }
+            // Even though we're not explicitly initializing the `Mapping`,
+            // we still need to call this
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.value = Default::default();
+            })
         }
 
         #[ink(message)]
@@ -40,18 +47,19 @@ mod incrementer {
 
         #[ink(message)]
         pub fn get_mine(&self) -> i32 {
-            self.my_value_or_zero(&self.env().caller())
+            self.my_value.get(&self.env().caller()).unwrap_or_default()
         }
 
         #[ink(message)]
         pub fn inc_mine(&mut self, by: i32) {
             // ACTION: Get the `caller` of this function.
-            // ACTION: Get `my_value` that belongs to `caller` by using `my_value_or_zero`.
+            // ACTION: Get `my_value` that belongs to `caller` by using `get_mine()`.
             // ACTION: Insert the incremented `value` back into the mapping.
         }
 
-        fn my_value_or_zero(&self, of: &AccountId) -> i32 {
-            *self.my_value.get(of).unwrap_or(&0)
+        #[ink(message)]
+        pub fn remove_mine(&self) {
+            // ACTION: Clear the value at that belongs to `caller` from storage.
         }
     }
 
@@ -86,6 +94,26 @@ mod incrementer {
             assert_eq!(contract.get_mine(), 5);
             contract.inc_mine(10);
             assert_eq!(contract.get_mine(), 15);
+        }
+
+        #[ink::test]
+        fn inc_mine_works() {
+            let mut contract = Incrementer::new(11);
+            assert_eq!(contract.get_mine(), 0);
+            contract.inc_mine(5);
+            assert_eq!(contract.get_mine(), 5);
+            contract.inc_mine(5);
+            assert_eq!(contract.get_mine(), 10);
+        }
+
+        #[ink::test]
+        fn remove_mine_works() {
+            let mut contract = Incrementer::new(11);
+            assert_eq!(contract.get_mine(), 0);
+            contract.inc_mine(5);
+            assert_eq!(contract.get_mine(), 5);
+            contract.remove_mine();
+            assert_eq!(contract.get_mine(), 0);
         }
     }
 }

--- a/static/assets/tutorials/ink-workshop/2.1-template.rs
+++ b/static/assets/tutorials/ink-workshop/2.1-template.rs
@@ -4,13 +4,15 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod erc20 {
+    // ACTION: Import and derive the required trait for initializing a contract
+
     #[cfg(not(feature = "ink-as-dependency"))]
     #[ink(storage)]
     pub struct Erc20 {
         /// The total supply.
         total_supply: Balance,
         /// The balance of each user.
-        balances: ink_storage::collections::HashMap<AccountId, Balance>,
+        balances: ink_storage::Mapping<AccountId, Balance>,
     }
 
     impl Erc20 {
@@ -18,6 +20,7 @@ mod erc20 {
         pub fn new(initial_supply: Balance) -> Self {
             // ACTION: `set` the total supply to `initial_supply`
             // ACTION: `insert` the `initial_supply` as the `caller` balance
+            // HINT: Remember to use the initialization utility function
         }
 
         #[ink(message)]
@@ -27,13 +30,8 @@ mod erc20 {
 
         #[ink(message)]
         pub fn balance_of(&self, owner: AccountId) -> Balance {
-            // ACTION: Return the balance of `owner`
-            //   HINT: Use `balance_of_or_zero` to get the `owner` balance
-        }
-
-        fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            // ACTION: `get` the balance of `owner`, then `unwrap_or` fallback to 0
-            // ACTION: Return the balance
+            // ACTION: Return the balance of `owner`, and fallback to
+            // a default value if there is no existing balance
         }
     }
 

--- a/static/assets/tutorials/ink-workshop/2.2-template.rs
+++ b/static/assets/tutorials/ink-workshop/2.2-template.rs
@@ -4,24 +4,26 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod erc20 {
+    use ink_storage::traits::SpreadAllocate;
+
     #[cfg(not(feature = "ink-as-dependency"))]
     #[ink(storage)]
+    #[derive(SpreadAllocate)]
     pub struct Erc20 {
         /// The total supply.
         total_supply: Balance,
         /// The balance of each user.
-        balances: ink_storage::collections::HashMap<AccountId, Balance>,
+        balances: ink_storage::Mapping<AccountId, Balance>,
     }
 
     impl Erc20 {
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            let mut balances = ink_storage::collections::HashMap::new();
-            balances.insert(Self::env().caller(), initial_supply);
-            Self {
-                total_supply: initial_supply,
-                balances
-            }
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.total_supply = initial_supply;
+                let caller = Self::env().caller();
+                contract.balances.insert(&caller, &initial_supply);
+            })
         }
 
         #[ink(message)]
@@ -31,26 +33,27 @@ mod erc20 {
 
         #[ink(message)]
         pub fn balance_of(&self, owner: AccountId) -> Balance {
-            self.balance_of_or_zero(&owner)
+            self.balances.get(&owner).unwrap_or_default()
         }
 
         #[ink(message)]
         pub fn transfer(&mut self, to: AccountId, value: Balance) -> bool {
-            // ACTION: Call the `transfer_from_to` with `from` as `self.env().caller()`
+            // ACTION: Call `transfer_from_to` with `from` as `self.env().caller()`
         }
 
-        fn transfer_from_to(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
+        fn transfer_from_to(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
             // ACTION: Get the balance for `from` and `to`
-            //   HINT: Use the `balance_of_or_zero` function to do this
+            //   HINT: Use the `balance_of` function to do this
             // ACTION: If `from_balance` is less than `value`, return `false`
             // ACTION: Insert new values for `from` and `to`
             //         * from_balance - value
             //         * to_balance + value
             // ACTION: Return `true`
-        }
-
-        fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            *self.balances.get(owner).unwrap_or(&0)
         }
     }
 

--- a/static/assets/tutorials/ink-workshop/2.3-finished-code.rs
+++ b/static/assets/tutorials/ink-workshop/2.3-finished-code.rs
@@ -4,14 +4,7 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod erc20 {
-    #[cfg(not(feature = "ink-as-dependency"))]
-    #[ink(storage)]
-    pub struct Erc20 {
-        /// The total supply.
-        total_supply: Balance,
-        /// The balance of each user.
-        balances: ink_storage::collections::HashMap<AccountId, Balance>,
-    }
+    use ink_storage::traits::SpreadAllocate;
 
     #[ink(event)]
     pub struct Transfer {
@@ -23,23 +16,30 @@ mod erc20 {
         value: Balance,
     }
 
+    #[cfg(not(feature = "ink-as-dependency"))]
+    #[ink(storage)]
+    #[derive(SpreadAllocate)]
+    pub struct Erc20 {
+        /// The total supply.
+        total_supply: Balance,
+        /// The balance of each user.
+        balances: ink_storage::Mapping<AccountId, Balance>,
+    }
+
     impl Erc20 {
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            let caller = Self::env().caller();
-            let mut balances = ink_storage::collections::HashMap::new();
-            balances.insert(caller, initial_supply);
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.total_supply = initial_supply;
+                let caller = Self::env().caller();
+                contract.balances.insert(&caller, &initial_supply);
 
-            Self::env().emit_event(Transfer {
-                from: None,
-                to: Some(caller),
-                value: initial_supply,
-            });
-
-            Self {
-                total_supply: initial_supply,
-                balances
-            }
+                Self::env().emit_event(Transfer {
+                    from: None,
+                    to: Some(caller),
+                    value: initial_supply,
+                });
+            })
         }
 
         #[ink(message)]
@@ -49,7 +49,7 @@ mod erc20 {
 
         #[ink(message)]
         pub fn balance_of(&self, owner: AccountId) -> Balance {
-            self.balance_of_or_zero(&owner)
+            self.balances.get(&owner).unwrap_or_default()
         }
 
         #[ink(message)]
@@ -57,18 +57,23 @@ mod erc20 {
             self.transfer_from_to(self.env().caller(), to, value)
         }
 
-        fn transfer_from_to(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
-            let from_balance = self.balance_of_or_zero(&from);
+        fn transfer_from_to(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
+            let from_balance = self.balance_of(from);
             if from_balance < value {
                 return false
             }
 
             // Update the sender's balance.
-            self.balances.insert(from, from_balance - value);
+            self.balances.insert(&from, &(from_balance - value));
 
             // Update the receiver's balance.
-            let to_balance = self.balance_of_or_zero(&to);
-            self.balances.insert(to, to_balance + value);
+            let to_balance = self.balance_of(to);
+            self.balances.insert(&to, &(to_balance + value));
 
             self.env().emit_event(Transfer {
                 from: Some(from),
@@ -77,10 +82,6 @@ mod erc20 {
             });
 
             true
-        }
-
-        fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            *self.balances.get(owner).unwrap_or(&0)
         }
     }
 

--- a/static/assets/tutorials/ink-workshop/2.3-template.rs
+++ b/static/assets/tutorials/ink-workshop/2.3-template.rs
@@ -4,14 +4,7 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod erc20 {
-    #[cfg(not(feature = "ink-as-dependency"))]
-    #[ink(storage)]
-    pub struct Erc20 {
-        /// The total supply.
-        total_supply: Balance,
-        /// The balance of each user.
-        balances: ink_storage::collections::HashMap<AccountId, Balance>,
-    }
+    use ink_storage::traits::SpreadAllocate;
 
     #[ink(event)]
     pub struct Transfer {
@@ -21,19 +14,27 @@ mod erc20 {
     //          * value: Balance
     }
 
+    #[cfg(not(feature = "ink-as-dependency"))]
+    #[ink(storage)]
+    #[derive(SpreadAllocate)]
+    pub struct Erc20 {
+        /// The total supply.
+        total_supply: Balance,
+        /// The balance of each user.
+        balances: ink_storage::Mapping<AccountId, Balance>,
+    }
+
     impl Erc20 {
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            let mut balances = ink_storage::collections::HashMap::new();
-            balances.insert(Self::env().caller(), initial_supply);
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.total_supply = initial_supply;
+                let caller = Self::env().caller();
+                contract.balances.insert(&caller, &initial_supply);
 
-            // ACTION: Call `Self::env().emit_event` with the `Transfer` event
-            //   HINT: Since we use `Option<AccountId>`, you need to wrap accounts in `Some()`
-
-            Self {
-                total_supply: initial_supply,
-                balances
-            }
+                // ACTION: Call `Self::env().emit_event` with the `Transfer` event
+                //   HINT: Since we use `Option<AccountId>`, you need to wrap accounts in `Some()`
+            })
         }
 
         #[ink(message)]
@@ -43,7 +44,7 @@ mod erc20 {
 
         #[ink(message)]
         pub fn balance_of(&self, owner: AccountId) -> Balance {
-            self.balance_of_or_zero(&owner)
+            self.balances.get(&owner).unwrap_or_default()
         }
 
         #[ink(message)]
@@ -51,26 +52,28 @@ mod erc20 {
             self.transfer_from_to(self.env().caller(), to, value)
         }
 
-        fn transfer_from_to(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
-            let from_balance = self.balance_of_or_zero(&from);
+        fn transfer_from_to(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
+            let from_balance = self.balance_of(from);
             if from_balance < value {
                 return false
             }
 
             // Update the sender's balance.
-            self.balances.insert(from, from_balance - value);
+            self.balances.insert(&from, &(from_balance - value));
 
             // Update the receiver's balance.
-            let to_balance = self.balance_of_or_zero(&to);
-            self.balances.insert(to, to_balance + value);
+            let to_balance = self.balance_of(to);
+            self.balances.insert(&to, &(to_balance + value));
 
             // ACTION: Call `self.env().emit_event` with the `Transfer` event
             //   HINT: Since we use `Option<AccountId>`, you need to wrap accounts in `Some()`
-            true
-        }
 
-        fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            *self.balances.get(owner).unwrap_or(&0)
+            true
         }
     }
 

--- a/static/assets/tutorials/ink-workshop/2.4-finished-code.rs
+++ b/static/assets/tutorials/ink-workshop/2.4-finished-code.rs
@@ -4,203 +4,241 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod erc20 {
-	#[cfg(not(feature = "ink-as-dependency"))]
-	#[ink(storage)]
-	pub struct Erc20 {
-		/// The total supply.
-		total_supply: Balance,
-		/// The balance of each user.
-		balances: ink_storage::collections::HashMap<AccountId, Balance>,
-		/// Approval spender on behalf of the message's sender.
-		allowances: ink_storage::collections::HashMap<(AccountId, AccountId), Balance>,
-	}
+    use ink_storage::traits::SpreadAllocate;
 
-	#[ink(event)]
-	pub struct Transfer {
-		#[ink(topic)]
-		from: Option<AccountId>,
-		#[ink(topic)]
-		to: Option<AccountId>,
-		#[ink(topic)]
-		value: Balance,
-	}
+    #[ink(event)]
+    pub struct Transfer {
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        #[ink(topic)]
+        value: Balance,
+    }
 
-	#[ink(event)]
-	pub struct Approval {
-		#[ink(topic)]
-		owner: AccountId,
-		#[ink(topic)]
-		spender: AccountId,
-		#[ink(topic)]
-		value: Balance,
-	}
+    #[ink(event)]
+    pub struct Approval {
+        #[ink(topic)]
+        owner: AccountId,
+        #[ink(topic)]
+        spender: AccountId,
+        #[ink(topic)]
+        value: Balance,
+    }
 
-	impl Erc20 {
-		#[ink(constructor)]
-		pub fn new(initial_supply: Balance) -> Self {
-			let caller = Self::env().caller();
-			let mut balances = ink_storage::collections::HashMap::new();
-			balances.insert(caller, initial_supply);
+    #[cfg(not(feature = "ink-as-dependency"))]
+    #[ink(storage)]
+    #[derive(SpreadAllocate)]
+    pub struct Erc20 {
+        /// The total supply.
+        total_supply: Balance,
+        /// The balance of each user.
+        balances: ink_storage::Mapping<AccountId, Balance>,
+        /// Approval spender on behalf of the message's sender.
+        allowances: ink_storage::Mapping<(AccountId, AccountId), Balance>,
+    }
 
-			Self::env().emit_event(Transfer {
-					from: None,
-					to: Some(caller),
-					value: initial_supply,
-			});
+    impl Erc20 {
+        #[ink(constructor)]
+        pub fn new(initial_supply: Balance) -> Self {
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.total_supply = initial_supply;
+                let caller = Self::env().caller();
+                contract.balances.insert(&caller, &initial_supply);
 
-			Self {
-					total_supply: initial_supply,
-					balances,
-					allowances: ink_storage::collections::HashMap::new(),
-			}
-		}
+                // NOTE: `allowances` is default initialized by `initialize_contract`, so we don't
+                // need to do anything here
 
-		#[ink(message)]
-		pub fn total_supply(&self) -> Balance {
-			self.total_supply
-		}
+                Self::env().emit_event(Transfer {
+                    from: None,
+                    to: Some(caller),
+                    value: initial_supply,
+                });
+            })
+        }
 
-		#[ink(message)]
-		pub fn balance_of(&self, owner: AccountId) -> Balance {
-			self.balance_of_or_zero(&owner)
-		}
+        #[ink(message)]
+        pub fn total_supply(&self) -> Balance {
+            self.total_supply
+        }
 
-		#[ink(message)]
-		pub fn approve(&mut self, spender: AccountId, value: Balance) -> bool {
-			// Record the new allowance.
-			let owner = self.env().caller();
-			self.allowances.insert((owner, spender), value);
+        #[ink(message)]
+        pub fn balance_of(&self, owner: AccountId) -> Balance {
+            self.balances.get(&owner).unwrap_or_default()
+        }
 
-			// Notify offchain users of the approval and report success.
-			self.env().emit_event(Approval {
-				owner,
-				spender,
-				value,
-			});
-			true
-		}
+        #[ink(message)]
+        pub fn approve(&mut self, spender: AccountId, value: Balance) -> bool {
+            // Record the new allowance.
+            let owner = self.env().caller();
+            self.allowances.insert(&(owner, spender), &value);
 
-		#[ink(message)]
-		pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
-			self.allowance_of_or_zero(&owner, &spender)
-		}
+            // Notify offchain users of the approval and report success.
+            self.env().emit_event(Approval {
+                owner,
+                spender,
+                value,
+            });
 
-		#[ink(message)]
-		pub fn transfer_from(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
-			// Ensure that a sufficient allowance exists.
-			let caller = self.env().caller();
-			let allowance = self.allowance_of_or_zero(&from, &caller);
-			if allowance < value {
-				return false;
-			}
+            true
+        }
 
-			let transfer_result = self.transfer_from_to(from, to, value);
-			// Check `transfer_result` because `from` account may not have enough balance
-			//   and return false.
-			if !transfer_result {
-				return false
-			}
+        #[ink(message)]
+        pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
+            self.allowance_of_or_zero(&owner, &spender)
+        }
 
-			// Decrease the value of the allowance and transfer the tokens.
-			self.allowances.insert((from, caller), allowance - value);
-			true
-		}
+        #[ink(message)]
+        pub fn transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
+            // Ensure that a sufficient allowance exists.
+            let caller = self.env().caller();
+            let allowance = self.allowance_of_or_zero(&from, &caller);
+            if allowance < value {
+                return false
+            }
 
-		#[ink(message)]
-		pub fn transfer(&mut self, to: AccountId, value: Balance) -> bool {
-			self.transfer_from_to(self.env().caller(), to, value)
-		}
+            let transfer_result = self.transfer_from_to(from, to, value);
+            // Check `transfer_result` because `from` account may not have enough balance
+            //   and return false.
+            if !transfer_result {
+                return false
+            }
 
-		fn transfer_from_to(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
-			let from_balance = self.balance_of_or_zero(&from);
-			if from_balance < value {
-				return false
-			}
+            // Decrease the value of the allowance and transfer the tokens.
+            self.allowances.insert((from, caller), &(allowance - value));
+            true
+        }
 
-			// Update the sender's balance.
-			self.balances.insert(from, from_balance - value);
+        #[ink(message)]
+        pub fn transfer(&mut self, to: AccountId, value: Balance) -> bool {
+            self.transfer_from_to(self.env().caller(), to, value)
+        }
 
-			// Update the receiver's balance.
-			let to_balance = self.balance_of_or_zero(&to);
-			self.balances.insert(to, to_balance + value);
+        fn transfer_from_to(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
+            let from_balance = self.balance_of(from);
+            if from_balance < value {
+                return false
+            }
 
-			self.env().emit_event(Transfer {
-				from: Some(from),
-				to: Some(to),
-				value,
-			});
+            // Update the sender's balance.
+            self.balances.insert(&from, &(from_balance - value));
 
-			true
-		}
+            // Update the receiver's balance.
+            let to_balance = self.balance_of(to);
+            self.balances.insert(&to, &(to_balance + value));
 
-		fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-			*self.balances.get(owner).unwrap_or(&0)
-		}
+            self.env().emit_event(Transfer {
+                from: Some(from),
+                to: Some(to),
+                value,
+            });
 
-		fn allowance_of_or_zero(&self, owner: &AccountId, spender: &AccountId) -> Balance {
-			// If you are new to Rust, you may wonder what's the deal with all the asterisks and
-			// ampersends.
-			//
-			// In brief, using `&` if we want to get the address of a value (aka reference of the
-			// value), and using `*` if we have the reference of a value and want to get the value
-			// back (aka dereferencing).
-			// To read more: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
-			*self.allowances.get(&(*owner, *spender)).unwrap_or(&0)
-		}
-	}
+            true
+        }
 
-	#[cfg(test)]
-	mod tests {
-		use super::*;
+        fn allowance_of_or_zero(
+            &self,
+            owner: &AccountId,
+            spender: &AccountId,
+        ) -> Balance {
+            // If you are new to Rust, you may wonder what's the deal with all the asterisks and
+            // ampersends.
+            //
+            // In brief, using `&` if we want to get the address of a value (aka reference of the
+            // value), and using `*` if we have the reference of a value and want to get the value
+            // back (aka dereferencing).
+            //
+            // To read more: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+            self.allowances.get(&(*owner, *spender)).unwrap_or_default()
+        }
+    }
 
-		use ink_lang as ink;
+    #[cfg(test)]
+    mod tests {
+        use super::*;
 
-		#[ink::test]
-		fn new_works() {
-			let contract = Erc20::new(777);
-			assert_eq!(contract.total_supply(), 777);
-		}
+        use ink_lang as ink;
 
-		#[ink::test]
-		fn balance_works() {
-			let contract = Erc20::new(100);
-			assert_eq!(contract.total_supply(), 100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
-		}
+        #[ink::test]
+        fn new_works() {
+            let contract = Erc20::new(777);
+            assert_eq!(contract.total_supply(), 777);
+        }
 
-		#[ink::test]
-		fn transfer_works() {
-			let mut contract = Erc20::new(100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			assert!(contract.transfer(AccountId::from([0x0; 32]), 10));
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
-			assert!(!contract.transfer(AccountId::from([0x0; 32]), 100));
-		}
+        #[ink::test]
+        fn balance_works() {
+            let contract = Erc20::new(100);
+            assert_eq!(contract.total_supply(), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
+        }
 
-		#[ink::test]
-		fn transfer_from_works() {
-			let mut contract = Erc20::new(100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			contract.approve(AccountId::from([0x1; 32]), 20);
-			contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 10);
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
-		}
+        #[ink::test]
+        fn transfer_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert!(contract.transfer(AccountId::from([0x0; 32]), 10));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
+            assert!(!contract.transfer(AccountId::from([0x0; 32]), 100));
+        }
 
-		#[ink::test]
-		fn allowances_works() {
-			let mut contract = Erc20::new(100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			contract.approve(AccountId::from([0x1; 32]), 200);
-			assert_eq!(contract.allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])), 200);
+        #[ink::test]
+        fn transfer_from_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            contract.approve(AccountId::from([0x1; 32]), 20);
+            contract.transfer_from(
+                AccountId::from([0x1; 32]),
+                AccountId::from([0x0; 32]),
+                10,
+            );
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
+        }
 
-			assert!(contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 50));
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
-			assert_eq!(contract.allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])), 150);
+        #[ink::test]
+        fn allowances_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            contract.approve(AccountId::from([0x1; 32]), 200);
+            assert_eq!(
+                contract
+                    .allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])),
+                200
+            );
 
-			assert!(!contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 100));
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
-			assert_eq!(contract.allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])), 150);
-		}
-	}
+            assert!(contract.transfer_from(
+                AccountId::from([0x1; 32]),
+                AccountId::from([0x0; 32]),
+                50
+            ));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
+            assert_eq!(
+                contract
+                    .allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])),
+                150
+            );
+
+            assert!(!contract.transfer_from(
+                AccountId::from([0x1; 32]),
+                AccountId::from([0x0; 32]),
+                100
+            ));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
+            assert_eq!(
+                contract
+                    .allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])),
+                150
+            );
+        }
+    }
 }

--- a/static/assets/tutorials/ink-workshop/2.4-template.rs
+++ b/static/assets/tutorials/ink-workshop/2.4-template.rs
@@ -4,161 +4,215 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod erc20 {
-	#[cfg(not(feature = "ink-as-dependency"))]
-	#[ink(storage)]
-	pub struct Erc20 {
-		/// The total supply.
-		total_supply: Balance,
-		/// The balance of each user.
-		balances: ink_storage::collections::HashMap<AccountId, Balance>,
-		/// Approval spender on behalf of the message's sender.
-		//  ACTION: Add an `allowances` storage item. It should be a
-		//         `HashMap` from `(AccountId, AccountId)` to `Balance`
-	}
+    use ink_storage::traits::SpreadAllocate;
 
-	#[ink(event)]
-	pub struct Transfer {
-		#[ink(topic)]
-		from: Option<AccountId>,
-		#[ink(topic)]
-		to: Option<AccountId>,
-		#[ink(topic)]
-		value: Balance,
-	}
+    #[ink(event)]
+    pub struct Transfer {
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        #[ink(topic)]
+        value: Balance,
+    }
 
-	// ACTION: Add an `Approval` event
-	//         It should emit the following:
-	//         * `owner` as an `AccountId`
-	//         * `spender` as an `AccountId`
-	//         * `value` as a `Balance`
+    // ACTION: Add an `Approval` event
+    //         It should emit the following:
+    //         * `owner` as an `AccountId`
+    //         * `spender` as an `AccountId`
+    //         * `value` as a `Balance`
 
-	impl Erc20 {
-		#[ink(constructor)]
-		pub fn new(initial_supply: Balance) -> Self {
-			let caller = Self::env().caller();
-			let mut balances = ink_storage::collections::HashMap::new();
-			balances.insert(caller, initial_supply);
+    #[cfg(not(feature = "ink-as-dependency"))]
+    #[ink(storage)]
+    #[derive(SpreadAllocate)]
+    pub struct Erc20 {
+        /// The total supply.
+        total_supply: Balance,
+        /// The balance of each user.
+        balances: ink_storage::Mapping<AccountId, Balance>,
+        /// Approval spender on behalf of the message's sender.
+        //  ACTION: Add an `allowances` storage item. It should be a
+        //          `Mapping` from `(AccountId, AccountId) to `Balance`
+    }
 
-			Self::env().emit_event(Transfer {
-				from: None,
-				to: Some(caller),
-				value: initial_supply,
-			});
+    impl Erc20 {
+        #[ink(constructor)]
+        pub fn new(initial_supply: Balance) -> Self {
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                contract.total_supply = initial_supply;
+                let caller = Self::env().caller();
+                contract.balances.insert(&caller, &initial_supply);
 
-			// ACTION: add allowances initialization
-			Self {
-				total_supply: initial_supply,
-				balances,
-			}
-		}
+                // NOTE: `allowances` is default initialized by `initialize_contract`, so we don't
+                // need to do anything here
 
-		#[ink(message)]
-		pub fn total_supply(&self) -> Balance {
-			self.total_supply
-		}
+                Self::env().emit_event(Transfer {
+                    from: None,
+                    to: Some(caller),
+                    value: initial_supply,
+                });
+            })
+        }
 
-		#[ink(message)]
-		pub fn balance_of(&self, owner: AccountId) -> Balance {
-			self.balance_of_or_zero(&owner)
-		}
+        #[ink(message)]
+        pub fn total_supply(&self) -> Balance {
+            self.total_supply
+        }
 
-		#[ink(message)]
-		pub fn approve(&mut self, spender: AccountId, value: Balance) -> bool {
-			// ACTION: Get the `self.env().caller()` and store it as the `owner`
-			// ACTION: Insert the new allowance into the `allowances` HashMap
-			//   HINT: The key tuple is `(owner, spender)`
-			// ACTION: `emit` the `Approval` event you created using these values
-			// ACTION: Return true if everything was successful
-		}
+        #[ink(message)]
+        pub fn balance_of(&self, owner: AccountId) -> Balance {
+            self.balances.get(&owner).unwrap_or_default()
+        }
 
-		#[ink(message)]
-		pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
-			// ACTION: Create a getter for the `allowances` HashMap
-			//   HINT: Take a look at the getters above if you forget the details
-			// ACTION: Return the `allowance` value
-		}
+        #[ink(message)]
+        pub fn approve(&mut self, spender: AccountId, value: Balance) -> bool {
+           // ACTION: Get the `self.env().caller()` and store it as the `owner`
+           // ACTION: Insert the new allowance into the `allowances` Mapping
+           //   HINT: The key tuple is `(owner, spender)`
+           // ACTION: `emit` the `Approval` event you created using these values
+           // ACTION: Return true if everything was successful
+        }
 
-		#[ink(message)]
-		pub fn transfer_from(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
-			// ACTION: Get the allowance for `(from, self.env().caller())` using `allowance_of_or_zero`
-			// ACTION: `if` the `allowance` is less than the `value`, exit early and return `false`
-			// ACTION: `insert` the new allowance into the map for `(from, self.env().caller())`
-			// ACTION: Finally, call the `transfer_from_to` for `from` and `to`
-			// ACTION: Return true if everything was successful
-		}
+        #[ink(message)]
+        pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
+            // ACTION: Create a getter for the `allowances` Mapping
+            //   HINT: Take a look at the getters above if you forget the details
+            // ACTION: Return the `allowance` value
+        }
 
-		#[ink(message)]
-		pub fn transfer(&mut self, to: AccountId, value: Balance) -> bool {
-			self.transfer_from_to(self.env().caller(), to, value)
-		}
+        #[ink(message)]
+        pub fn transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
+            // ACTION: Get the allowance for `(from, self.env().caller())` using `allowance_of_or_zero`
+            // ACTION: `if` the `allowance` is less than the `value`, exit early and return `false`
+            // ACTION: `insert` the new allowance into the map for `(from, self.env().caller())`
+            // ACTION: Finally, call the `transfer_from_to` for `from` and `to`
+            // ACTION: Return true if everything was successful
+        }
 
-		fn transfer_from_to(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
-			let from_balance = self.balance_of_or_zero(&from);
-			if from_balance < value {
-				return false
-			}
+        #[ink(message)]
+        pub fn transfer(&mut self, to: AccountId, value: Balance) -> bool {
+            self.transfer_from_to(self.env().caller(), to, value)
+        }
 
-			// Update the sender's balance.
-			self.balances.insert(from, from_balance - value);
+        fn transfer_from_to(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> bool {
+            let from_balance = self.balance_of(from);
+            if from_balance < value {
+                return false
+            }
 
-			// Update the receiver's balance.
-			let to_balance = self.balance_of_or_zero(&to);
-			self.balances.insert(to, to_balance + value);
+            // Update the sender's balance.
+            self.balances.insert(&from, &(from_balance - value));
 
-			self.env().emit_event(Transfer {
-				from: Some(from),
-				to: Some(to),
-				value,
-			});
+            // Update the receiver's balance.
+            let to_balance = self.balance_of(to);
+            self.balances.insert(&to, &(to_balance + value));
 
-			true
-		}
+            self.env().emit_event(Transfer {
+                from: Some(from),
+                to: Some(to),
+                value,
+            });
 
-		fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-			*self.balances.get(owner).unwrap_or(&0)
-		}
+            true
+        }
 
-		fn allowance_of_or_zero(&self, owner: &AccountId, spender: &AccountId) -> Balance {
-			// ACTION: `get` the `allowances` of `(owner, spender)` and `unwrap_or` return `0`.
-		}
-	}
+        fn allowance_of_or_zero(
+            &self,
+            owner: &AccountId,
+            spender: &AccountId,
+        ) -> Balance {
+            // ACTION: `get` the `allowances` of `(owner, spender)` and return a default if no
+            // allowance exists
+        }
+    }
 
-	#[cfg(test)]
-	mod tests {
-		use super::*;
+    #[cfg(test)]
+    mod tests {
+        use super::*;
 
-		use ink_lang as ink;
+        use ink_lang as ink;
 
-		#[ink::test]
-		fn new_works() {
-			let contract = Erc20::new(777);
-			assert_eq!(contract.total_supply(), 777);
-		}
+        #[ink::test]
+        fn new_works() {
+            let contract = Erc20::new(777);
+            assert_eq!(contract.total_supply(), 777);
+        }
 
-		#[ink::test]
-		fn balance_works() {
-			let contract = Erc20::new(100);
-			assert_eq!(contract.total_supply(), 100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
-		}
+        #[ink::test]
+        fn balance_works() {
+            let contract = Erc20::new(100);
+            assert_eq!(contract.total_supply(), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
+        }
 
-		#[ink::test]
-		fn transfer_works() {
-			let mut contract = Erc20::new(100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			assert!(contract.transfer(AccountId::from([0x0; 32]), 10));
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
-			assert!(!contract.transfer(AccountId::from([0x0; 32]), 100));
-		}
+        #[ink::test]
+        fn transfer_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert!(contract.transfer(AccountId::from([0x0; 32]), 10));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
+            assert!(!contract.transfer(AccountId::from([0x0; 32]), 100));
+        }
 
-		#[ink::test]
-		fn transfer_from_works() {
-			let mut contract = Erc20::new(100);
-			assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
-			contract.approve(AccountId::from([0x1; 32]), 20);
-			contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 10);
-			assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
-		}
-	}
+        #[ink::test]
+        fn transfer_from_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            contract.approve(AccountId::from([0x1; 32]), 20);
+            contract.transfer_from(
+                AccountId::from([0x1; 32]),
+                AccountId::from([0x0; 32]),
+                10,
+            );
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
+        }
+
+        #[ink::test]
+        fn allowances_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            contract.approve(AccountId::from([0x1; 32]), 200);
+            assert_eq!(
+                contract
+                    .allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])),
+                200
+            );
+
+            assert!(contract.transfer_from(
+                AccountId::from([0x1; 32]),
+                AccountId::from([0x0; 32]),
+                50
+            ));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
+            assert_eq!(
+                contract
+                    .allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])),
+                150
+            );
+
+            assert!(!contract.transfer_from(
+                AccountId::from([0x1; 32]),
+                AccountId::from([0x0; 32]),
+                100
+            ));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
+            assert_eq!(
+                contract
+                    .allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])),
+                150
+            );
+        }
+    }
 }
+

--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -143,7 +143,7 @@ flipper
 
 The ink! CLI automatically generates the source code for the "Flipper" contract, which is about the
 simplest "smart" contract you can build. You can take a sneak peak as to what will come by looking
-at the [Flipper Example](https://github.com/paritytech/ink/blob/v3.0.0-rc8/examples/flipper/lib.rs).
+at the [Flipper Example](https://github.com/paritytech/ink/blob/v3.0.0-rc9/examples/flipper/lib.rs).
 
 The Flipper contract is nothing more than a `bool` which gets flipped from true to false through the `flip()` function. We won't go deep into the details of this source code because we will be walking you through the steps of building a more advanced contract!
 

--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -244,7 +244,7 @@ After successfully installing [`substrate-contracts-node`](https://github.com/pa
 you can start a local development chain by running:
 
 ```bash
-substrate-contracts-node --dev --tmp
+substrate-contracts-node --dev
 ```
 
 ![Substrate Smart Contracts Node](/assets/tutorials/ink-workshop/start-canvas-node.png)

--- a/v3/tutorials/08-ink-workshop/b-develop-smart-contract/index.mdx
+++ b/v3/tutorials/08-ink-workshop/b-develop-smart-contract/index.mdx
@@ -133,10 +133,13 @@ Substrate contracts may store types that are encodable and decodable with
 types such as `bool`, `u{8,16,32,64,128}`, `i{8,16,32,64,128}`, `String`, tuples, and arrays.
 
 ink! provides Substrate specific types like `AccountId`, `Balance`, and `Hash` to smart contracts as if
-they were primitive types. ink! also provides storage types for more elaborate storage interactions through the storage module:
+they were primitive types.
+
+ink! also provides a [`Mapping`](https://paritytech.github.io/ink/ink_storage/struct.Mapping.html)
+type, which is a mapping of key-value pairs in storage.
 
 ```rust
-use ink_storage::collections::{Vec, HashMap, Stash, Bitvec};
+use ink_storage::Mapping;
 ```
 
 Here is an example of how you would store an `AccountId` and `Balance`:
@@ -160,7 +163,14 @@ mod MyContract {
 }
 ```
 
-You can find all the supported Substrate types in the [`ink_storage` crate](https://github.com/paritytech/ink/tree/master/crates/storage).
+You may also use some of the Rust standard library collections exposed by the
+[`ink_prelude`](https://paritytech.github.io/ink/ink_prelude/index.html), such as
+[`ink_prelude::vec::Vec`](https://paritytech.github.io/ink/ink_prelude/vec/struct.Vec.html) and
+[`ink_prelude::collections::HashMap`](https://paritytech.github.io/ink/ink_prelude/collections/struct.HashMap.html),
+as part of your contract's storage struct. Note however, that they are not optimized for
+being used as part of contract storage and will be
+[loaded eagerly](https://paritytech.github.io/ink-docs/datastructures/overview#eager-loading).
+This may have some performance implications depending on your use case.
 
 ### 2. Contract Deployment
 
@@ -314,45 +324,7 @@ impl MyContract {
 }
 ```
 
-### 2. Lazy Storage Values
-
-There is [a `Lazy` type](https://paritytech.github.io/ink/ink_storage/struct.Lazy.html) that can be
-used for ink! storage values that do not need to be loaded in some or most cases. Many simple ink!
-examples, including those in this workshop, do not require the use of `Lazy` values. Since there is
-some overhead associated with `Lazy` values, they should only be used where required.
-
-This is an example of using the `Lazy` type:
-
-```rust
-#[ink(storage)]
-pub struct MyContract {
-	// Store some number
-	my_number: ink_storage::Lazy<u32>,
-}
-
-impl MyContract {
-	#[ink(constructor)]
-	pub fn new(init_value: u32) -> Self {
-		Self {
-			my_number: ink_storage::Lazy::<u32>::new(init_value),
-		}
-	}
-
-	#[ink(message)]
-	pub fn my_setter(&mut self, new_value: u32) {
-		ink_storage::Lazy::<u32>::set(&mut self.my_number, new_value);
-	}
-
-	#[ink(message)]
-	pub fn my_adder(&mut self, add_value: u32) {
-		let my_number = &mut self.my_number;
-		let cur = ink_storage::Lazy::<u32>::get(my_number);
-		ink_storage::Lazy::<u32>::set(my_number, cur + add_value);
-	}
-}
-```
-
-### 3. Your Turn
+### 2. Your Turn
 
 Follow the `ACTION`s in the template code.
 
@@ -380,7 +352,8 @@ Let's now extend our Incrementer to not only manage one number, but to manage on
 
 ### 1. Storage HashMap
 
-In addition to storing individual values, ink! also supports `HashMap` which allows you to store items in a key-value mapping.
+In addition to storing individual values, ink! also provides a [`Mapping`](https://paritytech.github.io/ink/ink_storage/struct.Mapping.html)
+type which allows you to store items in a key-value mapping.
 
 Here is an example of a mapping from a user to a number:
 
@@ -388,56 +361,25 @@ Here is an example of a mapping from a user to a number:
 #[ink(storage)]
 pub struct MyContract {
 	// Store a mapping from AccountIds to a u32
-	my_number_map: ink_storage::collections::HashMap<AccountId, u32>,
+	my_number_map: ink_storage::Mapping<AccountId, u32>,
 }
 ```
 
 This means that for a given key, you can store a unique instance of a value type. In this case, each "user" gets their own number, and we can build logic so that only they can modify their own numbers.
 
-### 2. Storage HashMap API
+### 2.Initializing a HashMap
 
-You can find the full ink! HashMap API doc [here](https://paritytech.github.io/ink/ink_storage/collections/hashmap/struct.HashMap.html). Here are some of the most common functions you might use:
 
-```rust
-/// Inserts a key-value pair into the map.
-///
-/// Returns the previous value associated with the same key if any.
-/// If the map did not have this key present, `None` is returned.
-pub fn insert(&mut self, key: K, new_value: V) -> Option<V> {/* --snip-- */}
+In order to correctly initialize a `Mapping` we need two things:
+1. An implementation of the [`SpreadAllocate`](https://paritytech.github.io/ink/ink_storage/traits/trait.SpreadAllocate.html) trait on our storage struct
+2. The [`ink_lang::utils::initalize_contract`](https://paritytech.github.io/ink/ink_lang/utils/fn.initialize_contract.html) initializer
 
-/// Removes the key/value pair from the map associated with the given key.
-///
-/// - Returns the removed value if any.
-pub fn take<Q>(&mut self, key: &Q) -> Option<V> {/* --snip-- */}
+Not initializing storage before you use it is a common error that can break your smart
+contract. If you do not initialize your `Mapping`'s correctly you may end up with
+different `Mapping`'s operating on the same set of storage entries 😱.
 
-/// Returns a shared reference to the value corresponding to the key.
-///
-/// The key may be any borrowed form of the map's key type,
-/// but `Hash` and `Eq` on the borrowed form must match those for the key type.
-pub fn get<Q>(&self, key: &Q) -> Option<&V> {/* --snip-- */}
-
-/// Returns a mutable reference to the value corresponding to the key.
-///
-/// The key may be any borrowed form of the map's key type,
-/// but `Hash` and `Eq` on the borrowed form must match those for the key type.
-pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V> {/* --snip-- */}
-
-/// Returns `true` if there is an entry corresponding to the key in the map.
-pub fn contains_key<Q>(&self, key: &Q) -> bool {/* --snip-- */}
-
-/// Converts the OccupiedEntry into a mutable reference to the value in the entry
-/// with a lifetime bound to the map itself.
-pub fn into_mut(self) -> &'a mut V {/* --snip-- */}
-
-/// Gets the given key's corresponding entry in the map for in-place manipulation.
-pub fn entry(&mut self, key: K) -> Entry<K, V> {/* --snip-- */}
-```
-
-### 3.Initializing a HashMap
-
-As mentioned, not initializing storage before you use it is a common error that can break your smart contract. For each key in a storage value, the value needs to be set before you can use it. To do this, we will create a private function which handles when the value is set and when it is not, and make sure we never work with uninitialized storage.
-
-So given `my_number_map`, imagine we wanted the default value for any given key to be `0`. We can build a function like this:
+Below is an example of how to correctly initialize a `Mapping`, as well as how to write
+and read entries from it.
 
 ```rust
 
@@ -447,85 +389,53 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod mycontract {
+    use ink_storage::traits::SpreadAllocate;
 
-	#[ink(storage)]
-	pub struct MyContract {
-		// Store a mapping from AccountIds to a u32
-		my_number_map: ink_storage::collections::HashMap<AccountId, u32>,
-	}
+    #[ink(storage)]
+    #[derive(SpreadAllocate)]
+    pub struct MyContract {
+        // Store a mapping from AccountIds to a u32
+        map: ink_storage::Mapping<AccountId, u32>,
+    }
 
-	impl MyContract {
-		/// Public function.
-		/// Default constructor.
-		#[ink(constructor)]
-		pub fn default() -> Self {
-			Self {
-				my_number_map: Default::default(),
-			}
-		}
+    impl MyContract {
+        #[ink(constructor)]
+        pub fn new(count: u32) -> Self {
+            // This call is required in order to correctly initialize the
+            // `Mapping`s of our contract.
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
+                let caller = Self::env().caller();
+                contract.map.insert(&caller, &count);
+            })
+        }
 
-		/// Private function.
-		/// Returns the number for an AccountId or 0 if it is not set.
-		fn my_number_or_zero(&self, of: &AccountId) -> u32 {
-			let balance = self.my_number_map.get(of).unwrap_or(&0);
-			*balance
-		}
-	}
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            // Even though we're not explicitly initializing the `Mapping`,
+            // we still need to call this
+            ink_lang::utils::initialize_contract(|_| {})
+        }
+
+        // Grab the number at the caller's AccountID, if it exists
+        #[ink(message)]
+        pub fn get(&self) -> u32 {
+            let caller = Self::env().caller();
+            self.map.get(&caller).unwrap_or_default()
+        }
+    }
 }
 ```
 
-Here we see that after we `get` the reference from `my_number_map` we call `unwrap_or` which will either `unwrap` the reference, _or_ if there is no value, return some known reference. Then, when building functions that interact with this HashMap, you need to always remember to call this function rather than getting the value directly from storage.
-
-Here is an example:
-
-```rust
-
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use ink_lang as ink;
-
-#[ink::contract]
-mod mycontract {
-
-	#[ink(storage)]
-	pub struct MyContract {
-		// Store a mapping from AccountIds to a u32
-		my_number_map: ink_storage::collections::HashMap<AccountId, u32>,
-	}
-
-	impl MyContract {
-		// Get the value for a given AccountId
-		#[ink(message)]
-		pub fn get(&self, of: AccountId) -> u32 {
-			self.my_number_or_zero(&of)
-		}
-
-		// Get the value for the calling AccountId
-		#[ink(message)]
-		pub fn get_my_number(&self) -> u32 {
-			let caller = self.env().caller();
-			self.my_number_or_zero(&caller)
-		}
-
-		// Returns the number for an AccountId or 0 if it is not set.
-		fn my_number_or_zero(&self, of: &AccountId) -> u32 {
-			let value = self.my_number_map.get(of).unwrap_or(&0);
-			*value
-		}
-	}
-}
-```
-
-### 4. Contract Caller
+### 3. Contract Caller
 
 As you might have noticed in the example above, we use a special function called `self.env().caller()`. This function is available throughout the contract logic and will always return to you the contract caller.
 
 <Message
   type={`gray`}
   title={`Note`}
-  text={`The contract caller is not the same as the origin caller. 
-  If a user triggers a contract which then calls a subsequent contract, 
-  the \`self.env().caller()\` in the second contract will be the address 
+  text={`The contract caller is not the same as the origin caller.
+  If a user triggers a contract which then calls a subsequent contract,
+  the \`self.env().caller()\` in the second contract will be the address
   of the first contract, not the original user.`}
 />
 
@@ -560,7 +470,7 @@ mod mycontract {
 
 Then you can write permissioned functions which checks that the current caller is the owner of the contract.
 
-### 5. Your Turn
+### 4. Your Turn
 
 Follow the `ACTION`s in the template code to introduce a storage map to your contract.
 
@@ -582,63 +492,22 @@ Remember to run `cargo +nightly test` to test your work.
 
 The final step in our Incrementer contract is to allow users to update their own values.
 
-### 1. Modifying a HashMap
+### 1. Updating a Mapping
 
-Making changes to the value of a HashMap is just as sensitive as getting the value. If you try to modify some value before it has been initialized, your contract will panic!
+The `Mapping` API is quite low level. We can directly override a previous value held at a
+storage entry by calling `Mapping::insert()` with an existing key. The `Mapping` will do
+nothing to "protect" us in this case.
 
-But have no fear, we can continue to use the `my_number_or_zero` function we created to protect us from these situations!
+We can also update values by first reading them from storage using `Mapping::get()`, and
+then overriding the entry with `Mapping::insert()`.
 
-```rust
-impl MyContract {
+Note that if there is no existing value at a given key, `Mapping::get()` will return
+`None`.
 
-	/* --snip-- */
+### 2. Cleaning up
 
-	// Set the value for the calling AccountId
-	#[ink(message)]
-	pub fn set_my_number(&mut self, value: u32) {
-		let caller = self.env().caller();
-		self.my_number_map.insert(caller, value);
-	}
-
-	// Add a value to the existing value for the calling AccountId
-	#[ink(message)]
-	pub fn add_my_number(&mut self, value: u32) {
-		let caller = self.env().caller();
-		let my_number = self.my_number_or_zero(&caller);
-		self.my_number_map.insert(caller, my_number + value);
-	}
-
-	/// Returns the number for an AccountId or 0 if it is not set.
-	fn my_number_or_zero(&self, of: &AccountId) -> u32 {
-		*self.my_number_map.get(of).unwrap_or(&0)
-	}
-}
-```
-
-Here we have written two kinds of functions which modify a HashMap. One simply inserts the value
-directly into storage, with no need to read the value first, and another one modifies the existing
-value. Note how we can always `insert` the value without worry, as that initialized the value in
-storage, but before you can get or modify anything, we need to call `my_number_or_zero` to make
-sure we are working with a real value.
-
-### 2. Update or Insert (Upsert)
-
-We will not always have an existing value on our contract's storage. We can take advantage of the
-Rust `Option<T>` type to help us.
-If there's no value on the contract storage we will insert a new one; on the contrary if there is
-an existing value we will only update it.
-
-ink! HashMaps expose the well-known
-[**HashMap Entry API**](https://doc.rust-lang.org/beta/std/collections/hash_map/enum.Entry.html)
-that we can use to achieve this type of "upsert" behavior:
-
-```rust
-let caller = self.env().caller();
-self.my_number_map
-	.entry(caller)
-	.and_modify(|old_value| *old_value += by)
-	.or_insert(by);
-```
+Since `Mapping` is low level we're required to do clean-up ourselves. `Mapping` provides
+a `Mapping::remove()` method which clears the value at a given key from storage.
 
 ### 3. Your Turn
 

--- a/v3/tutorials/08-ink-workshop/b-develop-smart-contract/index.mdx
+++ b/v3/tutorials/08-ink-workshop/b-develop-smart-contract/index.mdx
@@ -350,7 +350,7 @@ Remember to run `cargo +nightly test` to test your work.
 
 Let's now extend our Incrementer to not only manage one number, but to manage one number per user!
 
-### 1. Storage HashMap
+### 1. Storage Mapping
 
 In addition to storing individual values, ink! also provides a [`Mapping`](https://paritytech.github.io/ink/ink_storage/struct.Mapping.html)
 type which allows you to store items in a key-value mapping.
@@ -367,7 +367,7 @@ pub struct MyContract {
 
 This means that for a given key, you can store a unique instance of a value type. In this case, each "user" gets their own number, and we can build logic so that only they can modify their own numbers.
 
-### 2.Initializing a HashMap
+### 2.Initializing a Mapping
 
 
 In order to correctly initialize a `Mapping` we need two things:

--- a/v3/tutorials/08-ink-workshop/c-build-erc20-contract/index.mdx
+++ b/v3/tutorials/08-ink-workshop/c-build-erc20-contract/index.mdx
@@ -88,13 +88,14 @@ contract ERC20Interface {
 
 In summary, it allows individuals to deploy their own cryptocurrency on top of an existing smart
 contract platform. There isn't much magic happening in this contract. Users balances are stored in a
-HashMap, and a set of APIs are built to allow users to transfer tokens they own or allow a third
+Mapping, and a set of APIs are built to allow users to transfer tokens they own or allow a third
 party to transfer some amount of tokens on their behalf. Most importantly, all of this logic is
 implemented ensuring that funds are not unintentionally created or destroyed, and that a user's
 funds are protected from malicious actors.
 
-Note that all the public functions return a `bool` which specifies if the call was successful or not.
-We will adhere to that specification.
+Note that all the public functions return a `bool` which specifies if the call was
+successful or not. Note that while a more idiomatic Rust approach would be to return
+`Result`s we will adhere to the Solidity specification for the sake of demonstration.
 
 ## Creating the ERC20 Template
 
@@ -114,7 +115,7 @@ You will notice that the template for the ERC20 token is VERY similar to the Inc
 The storage (so far) consists of:
 
 - `total_supply`: a storage `Value`, representing the total supply of tokens in our contract.
-- `balances`: a storage `HashMap`, representing the individual balance of each account.
+- `balances`: a storage `Mapping`, representing the individual balance of each account.
 
 ### 1. ERC20 Deployment
 
@@ -135,7 +136,6 @@ You need to:
 
 - Set up a constructor function which initializes the two storage items
 - Create getters for both storage items
-- Create a `balance_of_or_zero` function to handle reading values from the HashMap
 
 Remember to run `cargo +nightly test` to test your work.
 
@@ -207,7 +207,7 @@ the contract caller is always authorized to move their own funds.
 There really is not much to say about the simple math executed within a token transfer.
 
 1. First we get the current balance of both the `from` and `to` account, making sure to use our
-   `balance_of_or_zero()` getter.
+   `balance_of` getter.
 2. Then we make the logic check mentioned above to ensure the `from` balance has enough funds to
    send `value`.
 3. Finally, we subtract that `value` from the `from` balance and add it to the `to` balance and
@@ -262,7 +262,7 @@ the event data they can have _indexed fields_. We can do this by using the `#[in
 tag on that field.
 
 One way of retrieving data from an `Option<T>` variable is using the `.unwrap_or()` function. You may
-recall using this in the `my_value_or_zero()` and `balance_of_or_zero()` functions in this project
+recall using this in the `my_value_or_zero()` and `balance_of()` functions in this project
 and the Incrementer project.
 
 ### 2. Emitting Events
@@ -355,7 +355,7 @@ When an account calls `approve` multiple times, the approved value simply overwr
 value that was approved in the past. By default, the approved value between any two accounts is `0`,
 and a user can always call approve for `0` to revoke access to their funds from another account.
 
-To store approvals in our contract, we need to use a slightly fancy `HashMap`.
+To store approvals in our contract, we need to use a slightly more fancy `Mapping` key.
 
 Since each account can have a different amount approved for any other accounts to use, we need to
 use a tuple as our key which simply points to a balance value. Here is an example of what that
@@ -364,7 +364,7 @@ would look like:
 ```rust
 pub struct Erc20 {
 	/// Balances that are spendable by non-owners: (owner, spender) -> allowed
-	allowances: ink_storage::collections::HashMap<(AccountId, AccountId), Balance>,
+	allowances: ink_storage::Mapping<(AccountId, AccountId), Balance>,
 }
 ```
 
@@ -407,7 +407,7 @@ true
 
 Again, we exit early and return false if our authorization does not pass.
 
-If everything looks good though, we simply `insert` the updated allowance into the `allowance` HashMap (`let new_allowance = allowance - value`), and call the `transfer_from_to` between the specified `from` and `to` accounts.
+If everything looks good though, we simply `insert` the updated allowance into the `allowance` Mapping (`let new_allowance = allowance - value`), and call the `transfer_from_to` between the specified `from` and `to` accounts.
 
 ### 2. Be Careful!
 

--- a/v3/tutorials/08-ink-workshop/c-build-erc20-contract/index.mdx
+++ b/v3/tutorials/08-ink-workshop/c-build-erc20-contract/index.mdx
@@ -88,7 +88,7 @@ contract ERC20Interface {
 
 In summary, it allows individuals to deploy their own cryptocurrency on top of an existing smart
 contract platform. There isn't much magic happening in this contract. Users balances are stored in a
-Mapping, and a set of APIs are built to allow users to transfer tokens they own or allow a third
+`Mapping`, and a set of APIs are built to allow users to transfer tokens they own or allow a third
 party to transfer some amount of tokens on their behalf. Most importantly, all of this logic is
 implemented ensuring that funds are not unintentionally created or destroyed, and that a user's
 funds are protected from malicious actors.
@@ -407,7 +407,7 @@ true
 
 Again, we exit early and return false if our authorization does not pass.
 
-If everything looks good though, we simply `insert` the updated allowance into the `allowance` Mapping (`let new_allowance = allowance - value`), and call the `transfer_from_to` between the specified `from` and `to` accounts.
+If everything looks good though, we simply `insert` the updated allowance into the `allowance` `Mapping` (`let new_allowance = allowance - value`), and call the `transfer_from_to` between the specified `from` and `to` accounts.
 
 ### 2. Be Careful!
 


### PR DESCRIPTION
In our most recent release of ink! we removed all storage collections with the exception
of `Mapping`. I won't get into the details here, but if you're curious you can go read
about it in the [ink! release notes](https://github.com/paritytech/ink/releases/tag/v3.0.0-rc9).

This PR updates the ink! workshop to use this new storage collection, and removes
references to the deprecated storage data structures.
