### PR TITLE
Updates to remove `devhub/latest` tag

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,6 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.0.2.cjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 AS builder
+FROM node:fermium-stretch-slim AS builder
 EXPOSE 9000
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /app
 COPY . .
 RUN echo "GATSBY_IO_URL=https://www.substrate.io\nGATSBY_DOCS_URL=http://localhost:9000" \
   > .env.production
-RUN yarn install
+RUN yarn
 RUN yarn build
 CMD ["yarn", "gatsby", "serve", "-H", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,5 @@ WORKDIR /app
 COPY . .
 RUN echo "GATSBY_IO_URL=https://www.substrate.io\nGATSBY_DOCS_URL=http://localhost:9000" \
   > .env.production
-RUN yarn
-RUN yarn build
+RUN yarn && yarn build
 CMD ["yarn", "gatsby", "serve", "-H", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ WORKDIR /app
 COPY . .
 RUN echo "GATSBY_IO_URL=https://www.substrate.io\nGATSBY_DOCS_URL=http://localhost:9000" \
   > .env.production
-RUN yarn install && yarn build
+RUN yarn install
+RUN yarn build
 CMD ["yarn", "gatsby", "serve", "-H", "0.0.0.0"]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fmt": "prettier --config .prettierrc.js --write \"{!**/*.{js,jsx,ts,tsx,json},**/*.{md,mdx}}\"",
     "fmt:code": "prettier --config .prettierrc.js --write \"{**/*.{js,jsx,ts,tsx,json},!**/*.{md,mdx}}\"",
     "checklinks": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' http://localhost:9000",
-	"checklinks-local": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' --exclude='undefined' http://localhost:9000",
+    "checklinks-local": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' --exclude='undefined' http://localhost:9000",
     "lint": "eslint . --ext ts --ext tsx --ext js --ext jsx",
     "lint:tsc": "tsc -p tsconfig.json --noEmit"
   },

--- a/v3/how-to-guides/01-basics/a-pallet-integration/index.mdx
+++ b/v3/how-to-guides/01-basics/a-pallet-integration/index.mdx
@@ -62,11 +62,9 @@ You will learn how to include a custom internal pallet that implements an event 
 
    In `/runtime/Cargo.toml`, include your pallet as a local dependency in `std` and add `runtime-benchmarks`. For example:
 
-   ```TOML
+   ```toml
    # --snip--
-   [dependencies.pallet-something]
-   default-features = false
-   path = '../pallets/something'
+   pallet-something = { default-features = false,   path = '../pallets/something'
    version = '3.0.0'
    # --snip--
    [features]
@@ -83,14 +81,12 @@ You will learn how to include a custom internal pallet that implements an event 
 
 **External pallets**
 
-The following is an example of how you would add an external pallet if the pallet is hosted in [crates.parity.io](https://crates.parity.io/):
+The following is an example of how you would add an external pallet if the pallet is hosted on [crates.parity.io](https://crates.parity.io/):
 
-```TOML
-[dependencies.pallet-external]
-default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = 'd6c33e7ec313f9bd5e319dc0a5a3ace5543f9617'
-version = '3.0.0'
+```toml
+[dependencies]
+pallet-external = {default-features = false, git = "https://github.com/paritytech/substrate.git", version = "4.0.0-dev"}
+
 # --snip--
 runtime-benchmarks = [
   /* --snip */

--- a/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/g-loose-coupling/index.mdx
@@ -36,7 +36,7 @@ pallet you want to couple to accordingly:
 
 ```toml
 [dependencies]
-frame-support = { default-features = false, git = 'https://github.com/paritytech/substrate.git', tag = 'devhub/latest', version = '4.0.0-dev' }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17", version = "4.0.0-dev" }
 
 # -- snip
 

--- a/v3/how-to-guides/03-weights/b-benchmarking/index.mdx
+++ b/v3/how-to-guides/03-weights/b-benchmarking/index.mdx
@@ -41,19 +41,14 @@ This guide does not cover updating weights with benchmarked values.
    `pallets/example/Cargo.toml`
 
    ```toml
-   [dependencies.frame-benchmarking]
-   default-features = false
-   git = 'https://github.com/paritytech/substrate.git'
-   optional = true
-   tag = '<monthly>'
-   version = '<version>'
+   frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true, branch = "<polkadot-vM.m.p>" }
 
    [features]
    # -- snip --
    runtime-benchmarks = ["frame-benchmarking"]
    std = [
      # -- snip --
-     'frame-benchmarking/std',
+     "frame-benchmarking/std",
    ]
    ```
 
@@ -133,10 +128,7 @@ benchmarking.
 1. Update your runtime's `Cargo.toml` file to include the `runtime-benchmarking` features:
 
    ```toml
-   [dependencies.pallet-you-created]
-   default-features = false
-   path = '../pallets/pallet-you-created'
-   version = '4.0.0-dev'
+   pallet-you-created = { default-features = false, path = "../pallets/pallet-you-created"}
 
    [features]
    runtime-benchmarks = [

--- a/v3/how-to-guides/04-ocw/a-transactions/index.mdx
+++ b/v3/how-to-guides/04-ocw/a-transactions/index.mdx
@@ -201,7 +201,7 @@ You will need to initialize this account in the next step.
     - Sign the raw payload with the account public key.
     - Finally, bundle all data up and return a tuple of the call, the caller, its signature, and any signed extension data.
 
-  You can see a full example of the code in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/devhub/latest/bin/node/runtime/src/lib.rs).
+  You can see a full example of the code in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/bin/node/runtime/src/lib.rs).
 
 8. Implement `SigningTypes` and `SendTransactionTypes` in the runtime to support submitting transactions, whether they are signed or unsigned.
 
@@ -220,7 +220,7 @@ You will need to initialize this account in the next step.
   }
   ```
 
-  You can see an example of this implementation in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/devhub/latest/bin/node/runtime/src/lib.rs#L1001-L1012).
+  You can see an example of this implementation in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/bin/node/runtime/src/lib.rs#L1103-L1114).
 
 9. Inject an account for this pallet to own. 
   In a development environment (node running with `--dev` flag), this account key is inserted in the `node/src/service.rs` file as follows:
@@ -300,7 +300,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
 
   In this example, users can call the on-chain `extrinsic1` function without a signature, but not any other extrinsics.
 
-  To see a full example of how `ValidateUnsigned` is implemented in a pallet, refer to [`pallet-ocw` in **Substrate Off-chain Worker Demo**](https://github.com/jimmychu0807/substrate-offchain-worker-demo/blob/v2.0.0/pallets/ocw/src/lib.rs#L209-L240) and [`pallet-example-offchain-worker` in **Substrate**](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker/src/lib.rs#L297-L325).
+  To see a full example of how `ValidateUnsigned` is implemented in a pallet, refer to  [`pallet-example-offchain-worker` in **Substrate**](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker/src/lib.rs#L301-L329).
 
 2. In the off-chain worker function, you can send unsigned transactions as follows:
 
@@ -344,7 +344,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
 
 4. Implement the `SendTransactionTypes` trait for the runtime as described in [sending signed transactions](#sending-signed-transactions).
 
-You can see a full example in [`pallet-example-offchain-worker` in **Substrate** code base](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker).
+You can see a full example in [`pallet-example-offchain-worker` in **Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker).
 
 ## Sending unsigned transactions with signed payloads
 
@@ -376,7 +376,7 @@ The differences between sending unsigned transactions and sending unsigned trans
   }
   ```
 
-  You can also see an example [here](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker/src/lib.rs#L344-L357).
+  You can also see an example [here](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker/src/lib.rs#L348-L361).
 
 1. In your pallet's `offchain_worker` function, call the signer, then the function to send the transaction:
 
@@ -454,7 +454,7 @@ The differences between sending unsigned transactions and sending unsigned trans
 
   This example uses [`SignedPayload`](https://paritytech.github.io/substrate/latest/frame_system/offchain/trait.SignedPayload.html) to verify that the public key in the payload has the same signature as the one provided.
 
-Refer to the [off-chain function call](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker/src/lib.rs#L505-L532) and [the implementation of `ValidateUnsigned`](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker/src/lib.rs#L308-L318) for a working example of the above.
+Refer to the [off-chain function call](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker/src/lib.rs#L508-L536) and [the implementation of `ValidateUnsigned`](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker/src/lib.rs#L305-L329) for a working example of the above.
 
 
 You have now seen how you can use off-chain workers to send data for on-chain storage using:
@@ -465,7 +465,7 @@ You have now seen how you can use off-chain workers to send data for on-chain st
 
 ## Examples
 
-- [Substrate Offchain Worker Example Pallet](https://github.com/paritytech/substrate/tree/devhub/latest/frame/examples/offchain-worker)
+- [Substrate Offchain Worker Example Pallet](https://github.com/paritytech/substrate/tree/polkadot-v0.9.17/frame/examples/offchain-worker)
 - [OCW Pallet in Substrate Offchain Worker Demo](https://github.com/jimmychu0807/substrate-offchain-worker-demo/tree/v2.0.0/pallets/ocw)
 
 ## Related material

--- a/v3/how-to-guides/04-ocw/b-http-requests/index.mdx
+++ b/v3/how-to-guides/04-ocw/b-http-requests/index.mdx
@@ -102,6 +102,6 @@ The Substrate HTTP library supports the following methods:
 
 ## Examples
 
-- [**Offchain Worker Example Pallet** in Substrate](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker/src/lib.rs#L568-#L621)
+- [**Offchain Worker Example Pallet** in Substrate](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker/src/lib.rs#L571-L625)
 - [**OCW Pallet** in Substrate Offchain Worker Demo](https://github.com/jimmychu0807/substrate-offchain-worker-demo/blob/master/pallets/ocw/src/lib.rs#L363-#L401)
 - [**Offchain HTTP source** in Substrate Core](https://github.com/paritytech/substrate/blob/master/primitives/runtime/src/offchain/http.rs#L63-L76)

--- a/v3/how-to-guides/04-ocw/c-local-storage/index.mdx
+++ b/v3/how-to-guides/04-ocw/c-local-storage/index.mdx
@@ -165,5 +165,5 @@ If the cached value is found, off-chain worker returns; else it will try to acqu
 
 ## Examples
 
-- [**Off-chain worker example pallet** in Substrate](https://github.com/paritytech/substrate/blob/devhub/latest/frame/examples/offchain-worker/src/lib.rs#L374-L437)
+- [**Off-chain worker example pallet** in Substrate](https://github.com/paritytech/substrate/blob/polkadot-v0.9.17/frame/examples/offchain-worker/src/lib.rs#L372-L441)
 - [**OCW pallet** demo](https://github.com/jimmychu0807/substrate-offchain-worker-demo/blob/master/pallets/ocw/src/lib.rs#L299-L342)

--- a/v3/how-to-guides/09-tools/a-integrate-try-runtime/index.mdx
+++ b/v3/how-to-guides/09-tools/a-integrate-try-runtime/index.mdx
@@ -47,8 +47,8 @@ Add the FRAME dependency:
 
 ```rust
 [dependencies]
-frame-try-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
-try-runtime-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17", optional = true }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17", optional = true }
 
 /* --snip-- */
     std = [
@@ -96,8 +96,8 @@ try-runtime = [
 ]
 
 /* --snip-- */
-frame-try-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
-try-runtime-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17", optional = true }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17", optional = true }
 /* --snip-- */
 
 ```

--- a/v3/how-to-guides/09-tools/a-integrate-try-runtime/index.mdx
+++ b/v3/how-to-guides/09-tools/a-integrate-try-runtime/index.mdx
@@ -33,8 +33,8 @@ which steps through which dependencies to include and where to include them in o
 <br />
 <Message
   type={`red`}
-  title={`Warning`}
-  text={`Be sure to use the \`devhub/latest\` tag when adding your dependencies.`}
+  title={`Match versions!`}
+  text={`Be sure to use the correct tag/branch when adding your dependencies!`}
 />
 
 ## Steps
@@ -47,8 +47,8 @@ Add the FRAME dependency:
 
 ```rust
 [dependencies]
-frame-try-runtime = { git = 'https://github.com/paritytech/substrate.git', tag = 'devhub/latest', optional = true }
-try-runtime-cli = { git = 'https://github.com/paritytech/substrate.git', tag = 'devhub/latest', optional = true }
+frame-try-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
+try-runtime-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
 
 /* --snip-- */
     std = [
@@ -96,8 +96,8 @@ try-runtime = [
 ]
 
 /* --snip-- */
-frame-try-runtime = { git = 'https://github.com/paritytech/substrate.git', tag = 'devhub/latest', optional = true }
-try-runtime-cli = { git = 'https://github.com/paritytech/substrate.git', tag = 'devhub/latest', optional = true }
+frame-try-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
+try-runtime-cli = { git = 'https://github.com/paritytech/substrate.git', branch = "polkadot-v0.9.17", optional = true }
 /* --snip-- */
 
 ```

--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -233,7 +233,7 @@ To add the `sp-std` crate to the pallet:
    [dependencies.sp-std]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'devhub/latest'      # or another tag that is **uniform** for you project
+   branch = "polkadot-v0.9.17"      # or another tag/branch that is **uniform** for you project
    version = '4.0.0-dev'      # or the latest version
    ```
 

--- a/v3/tutorials/02-proof-of-existence/index.mdx
+++ b/v3/tutorials/02-proof-of-existence/index.mdx
@@ -230,11 +230,7 @@ To add the `sp-std` crate to the pallet:
 1. Add the following `sp-std` dependencies section to the file:
 
    ```toml
-   [dependencies.sp-std]
-   default-features = false
-   git = 'https://github.com/paritytech/substrate.git'
-   branch = "polkadot-v0.9.17"      # or another tag/branch that is **uniform** for you project
-   version = '4.0.0-dev'      # or the latest version
+   sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
    ```
 
 1. Add the `sp-std` crate to the list of features.

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -140,12 +140,8 @@ First we must add the pallet to our runtime dependencies:
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies.pallet-node-authorization]
-default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-branch = "polkadot-v0.9.17"
-version = '4.0.0-dev'
+```toml
+pallet-node-authorization = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
 
 #--snip--
 [features]
@@ -214,7 +210,7 @@ construct_runtime!(
 
 **`node/cargo.toml`**
 
-```TOML
+```toml
 [dependencies]
 #--snip--
 bs58 = "0.4.0"

--- a/v3/tutorials/03-permissioned-network/index.mdx
+++ b/v3/tutorials/03-permissioned-network/index.mdx
@@ -144,7 +144,7 @@ First we must add the pallet to our runtime dependencies:
 [dependencies.pallet-node-authorization]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'devhub/latest'
+branch = "polkadot-v0.9.17"
 version = '4.0.0-dev'
 
 #--snip--

--- a/v3/tutorials/04-forkless-upgrades/index.mdx
+++ b/v3/tutorials/04-forkless-upgrades/index.mdx
@@ -224,7 +224,7 @@ First, add the Scheduler pallet as a dependency in the template node's runtime C
 [dependencies.pallet-scheduler]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'devhub/latest'
+branch = "polkadot-v0.9.17"
 version = '4.0.0-dev'
 
 #--snip--

--- a/v3/tutorials/04-forkless-upgrades/index.mdx
+++ b/v3/tutorials/04-forkless-upgrades/index.mdx
@@ -221,11 +221,7 @@ First, add the Scheduler pallet as a dependency in the template node's runtime C
 **`runtime/Cargo.toml`**
 
 ```toml
-[dependencies.pallet-scheduler]
-default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-branch = "polkadot-v0.9.17"
-version = '4.0.0-dev'
+pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
 
 #--snip--
 

--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -81,7 +81,7 @@ To add the Nicks pallet to the Substrate node template:
    [dependencies.pallet-nicks]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'devhub/latest'
+   branch = "polkadot-v0.9.17"
    version = '4.0.0-dev'
    ```
 

--- a/v3/tutorials/07-add-a-pallet/index.mdx
+++ b/v3/tutorials/07-add-a-pallet/index.mdx
@@ -77,26 +77,22 @@ To add the Nicks pallet to the Substrate node template:
 1. Import the `pallet-nicks` crate to make it available to the node template runtime by adding it to the
    list of dependencies.
 
-   ```TOML
-   [dependencies.pallet-nicks]
-   default-features = false
-   git = 'https://github.com/paritytech/substrate.git'
-   branch = "polkadot-v0.9.17"
-   version = '4.0.0-dev'
+   ```toml
+   pallet-nicks = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
    ```
 
-In this `dependencies.pallet-nicks` section, the`default-features = false` setting specifies that the pallet features are not used by default when compiling the runtime.
+In this `dependencies` section, the`default-features = false` setting specifies that the pallet features are not used by default when compiling the runtime.
 Instead, the features that are compiled for the runtime are controlled by specifying which features to include when compiling the native Rust binary listed in a separate `features` section.
 
-Because the Substrate runtime compiles to both a native Rust binary with standard library functions [`std`](https://doc.rust-lang.org/std/) and a [WebAssembly (Wasm)](https://webassembly.org/) binary that does not include the standard library, the pallet features that get compiled depend on whether you are compiling the Rust binary (`std` feaures) or the WebAssembly binary (`no-std`). For more information about compiling [`std`](https://doc.rust-lang.org/std/) and [`no_std`](https://rust-embedded.github.io/book/intro/no-std.html) features, see the [Rust Embedded Book](https://docs.rust-embedded.org/book/intro/no-std.html#summary).
+Because the Substrate runtime compiles to both a native Rust binary with standard library functions [`std`](https://doc.rust-lang.org/std/) and a [WebAssembly (Wasm)](https://webassembly.org/) binary that does not include the standard library, the pallet features that get compiled depend on whether you are compiling the Rust binary (`std` features) or the WebAssembly binary (`no-std`). For more information about compiling [`std`](https://doc.rust-lang.org/std/) and [`no_std`](https://rust-embedded.github.io/book/intro/no-std.html) features, see the [Rust Embedded Book](https://docs.rust-embedded.org/book/intro/no-std.html#summary).
 
-   The remaining lines specify that Cargo should use the `pallet-nicks` crate from the `paritytech/substrate` repository with the commit tag identified using the `devhub/latest` tag.
+   The remaining lines specify that Cargo should use the `pallet-nicks` crate from the `paritytech/substrate` repository with the correct *matching* version of substrate all other crates are using.
 
    For an introduction to editing `Cargo.toml` files, see the [Cargo reference documentation](https://doc.rust-lang.org/cargo/reference/index.html).
 
 1. Add the `pallet-nicks` crate to the list of `features` to be included in the `std` feature set by adding the following line `features` section.
 
-   ```TOML
+   ```toml
    [features]
    default = ['std']
    std = [
@@ -484,16 +480,13 @@ Once published, other developers could refer to your pallet in their `Cargo.toml
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies.your-pallet-name]
-default_features = false
-git = 'https://github.com/your-username/your-pallet'
-version = '1.0.0'
-branch = 'master'
+```toml
+your-pallet-name = { default_features = false, git = "https://github.com/your-username/your-pallet", version = "1.0.0" }
 
-# You may choose to refer to a specific commit or tag instead of branch
-# rev = '<git-commit>'
-# tag = '<some tag>
+# You may choose to refer to a specific commit, tag, or branch instead of (or in addition to, over-specifying) a version
+# rev = "<git-commit>""
+# tag = "<some tag>"
+# branch = "<some branch>"
 ```
 
 ### Option 2: Publishing on crates.io
@@ -505,10 +498,9 @@ Once published, other developers could refer to your pallet in their `Cargo.toml
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies.your-pallet-name]
-default_features = false
-version = 'some-compatible-version'
+```toml
+[dependencies]
+your-pallet-name = { default_features = false, version = "some-compatible-version"}
 ```
 
 We do not specify any target destination on the above, and by default it will search for the package in **crates.io** repository.

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -258,7 +258,7 @@ Just like the [helper files](https://github.com/substrate-developer-hub/substrat
    [dependencies.sp-io]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'devhub/latest'
+   branch = "polkadot-v0.9.17"
    version = '4.0.0-dev'
    ```
 

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -255,11 +255,7 @@ Just like the [helper files](https://github.com/substrate-developer-hub/substrat
    Ensure that this is declared as a dependency in your pallet's `Cargo.toml` file:
 
    ```toml
-   [dependencies.sp-io]
-   default-features = false
-   git = 'https://github.com/paritytech/substrate.git'
-   branch = "polkadot-v0.9.17"
-   version = '4.0.0-dev'
+   sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
    ```
 
 1. Now try running the following command to build your pallet. We won't build the entire chain just yet because we haven't yet implemented the `Currency` type in our runtime.
@@ -423,12 +419,7 @@ pub mod pallet {
 ```
 
 Along with this code, we'll need to import `serde`.
-Add this to your pallet's Cargo.toml file:
-
-```toml
-[dependencies.serde]
-version =  '1.0.129'
-```
+Add this to your pallet's Cargo.toml file, using the matching version as Substrate upstream.
 
 ### Scaffold Kitty struct
 
@@ -523,13 +514,7 @@ To create it, you'll build out the following parts:
 
    Notice the use of the [derive macro][derive-macro-rust] which must precede the enum declaration.
    This wraps our enum in the data structures it will need to interface with other types in our runtime.
-   In order to use `Serialize` and `Deserialize`, you will need to add the `serde` crate in `pallets/kitties/Cargo.toml`:
-
-   ```toml
-   [dependencies.serde]
-   default-features = false
-   version = '1.0.119'
-   ```
+   In order to use `Serialize` and `Deserialize`, you will need to add the `serde` crate in `pallets/kitties/Cargo.toml`, using the matching version as Substrate upstream.
 
    Great, we now know how to create a custom struct.
    But what about providing a way for a Kitty struct to be _assigned_ a gender value?
@@ -796,13 +781,7 @@ pub fn create_kitty(origin: OriginFor<T>) -> DispatchResult {
 ```
 
 We won't go into [debugging](/v3/runtime/debugging/), but logging to the console is a useful tip to make sure your pallet is behaving as expected.
-In order to use `log::info`, add this to your pallet's `Cargo.toml` file:
-
-```toml
-[dependencies.log]
-default-features = false
-version = '0.4.14'
-```
+In order to use `log::info`, add this to your pallet's `Cargo.toml` file, using the matching version as Substrate upstream.
 
 ### Write the `mint()` function
 


### PR DESCRIPTION
We will use explicit polkadot release versions for now. This also removed some lingering issues with toml snippets and explicit versions called out that are not maintained. 