### PR TITLE
Update substrate-contracts-node tag version

### DIFF
--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -81,7 +81,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 We need to use a Substrate node with the built-in `pallet-contracts` pallet. For this workshop we'll use a pre-configured Substrate node client.
 
 ```bash
-cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --tag v0.7.0 --force --locked
+cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --tag v0.8.0 --force --locked
 ```
 
 ### 2. ink! CLI

--- a/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
+++ b/v3/tutorials/08-ink-workshop/a-getting-started/index.mdx
@@ -81,7 +81,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 We need to use a Substrate node with the built-in `pallet-contracts` pallet. For this workshop we'll use a pre-configured Substrate node client.
 
 ```bash
-cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --tag v0.6.0 --force --locked
+cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --tag v0.7.0 --force --locked
 ```
 
 ### 2. ink! CLI


### PR DESCRIPTION
Ink tutorial was [updated](https://github.com/substrate-developer-hub/substrate-docs/commit/1dd2009b7c795d601d70a776feaa0c0722a85dce) for substrate v3, as well as [contract-node template](https://github.com/paritytech/substrate-contracts-node) in tag v0.7.0, but `substrate-contracts-node` installation command is still on tag v0.6.0