### PR TITLE
fix pallet::Error KittyExists not found

### DIFF
--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -951,9 +951,9 @@ ExceedMaxKittyOwned,
 BuyerIsKittyOwner,
 /// Cannot transfer a kitty to its owner.
 TransferToSelf,
-/// Handles checking whether the Kitty exists.
+/// This kitty already exists
 KittyExists
-/// Handles checking whether the Kitty exists.
+/// This kitty doesn't exist
 KittyNotExist,
 /// Handles checking that the Kitty is owned by the account transferring, buying or setting a price for it.
 NotKittyOwner,

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -952,6 +952,8 @@ BuyerIsKittyOwner,
 /// Cannot transfer a kitty to its owner.
 TransferToSelf,
 /// Handles checking whether the Kitty exists.
+KittyExists
+/// Handles checking whether the Kitty exists.
 KittyNotExist,
 /// Handles checking that the Kitty is owned by the account transferring, buying or setting a price for it.
 NotKittyOwner,


### PR DESCRIPTION
fix no variant or associated item named `KittyExists` found for enum `pallet::Error` in the current scope