### PR TITLE
update pallet attr documentation

### DIFF
--- a/v3/docs/03-runtime/a-FRAME/index.mdx
+++ b/v3/docs/03-runtime/a-FRAME/index.mdx
@@ -78,7 +78,6 @@ pub mod pallet {
 	// This is a placeholder to implement traits and methods.
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]
-    #[pallet::generate_storage_info]
     pub struct Pallet<T>(_);
 
 	// 3. Runtime Configuration Trait

--- a/v3/docs/03-runtime/b-macros/index.mdx
+++ b/v3/docs/03-runtime/b-macros/index.mdx
@@ -191,24 +191,24 @@ pub struct Pallet<T>(_);
 
 **When to use**
 
-You should not need to explicitly add this attribute.
-It is now assumed by default that all of the pallet storage items are bounded (i.e. have a fixed size).
+This attribute is now a no_op. It is now assumed by default that all of the pallet storage items are bounded (i.e. have a fixed size).
+You should not need to use this attribute.
 
 **What it does**
 
-This requires all storage to implement the trait `traits::StorageInfoTrait`, thus all keys and value types must bound `pallet_prelude::MaxEncodedLen`.
+All storage is now required to implement the trait `traits::StorageInfoTrait`, and thus all keys and value types must have the bound `pallet_prelude::MaxEncodedLen`.
 Individual storage can opt-out from this constraint by using `#[pallet::unbounded]`, see `#[pallet::storage]` documentation.
 
-This is an example of its definition:
+In the unlikely event that the entire pallet's storage needs to be unbounded by default, one can add the `#[pallet::without_storage_info]` attribute to the pallet struct like so:
 
 ```rust
 #[pallet::pallet]
 #[pallet::generate_store(pub(super) trait Store)]
-#[pallet::generate_storage_info]
+#[pallet::without_storage_info]
 pub struct Pallet<T>(_);
 ```
 
-In the unlikely event that the pallet's storage needs to be unbounded by default, you can add the `#[pallet::without_storage_info]` attribute.
+(but as discussed it would be more typical to place `#[pallet::unbounded]` on specific storage items)
 
 **Docs**
 

--- a/v3/docs/03-runtime/b-macros/index.mdx
+++ b/v3/docs/03-runtime/b-macros/index.mdx
@@ -180,7 +180,6 @@ This is an example of its definition:
 ```rust
 #[pallet::pallet]
 #[pallet::generate_store(pub(super) trait Store)]
-#[pallet::generate_storage_info]
 pub struct Pallet<T>(_);
 ```
 
@@ -192,11 +191,13 @@ pub struct Pallet<T>(_);
 
 **When to use**
 
-Highly encouraged, but optional which will help ensure all of your pallet storage items are bounded.
+You should not need to explicitly add this attribute.
+It is now assumed by default that all of the pallet storage items are bounded (i.e. have a fixed size).
 
 **What it does**
 
-This requires all storage to implement the trait `traits::StorageInfoTrait`, thus all keys and value types must bound `pallet_prelude::MaxEncodedLen`. Some individual storage can opt-out from this constraint by using `#[pallet::unbounded]`, see `#[pallet::storage]` documentation.
+This requires all storage to implement the trait `traits::StorageInfoTrait`, thus all keys and value types must bound `pallet_prelude::MaxEncodedLen`.
+Individual storage can opt-out from this constraint by using `#[pallet::unbounded]`, see `#[pallet::storage]` documentation.
 
 This is an example of its definition:
 
@@ -206,6 +207,8 @@ This is an example of its definition:
 #[pallet::generate_storage_info]
 pub struct Pallet<T>(_);
 ```
+
+In the unlikely event that the pallet's storage needs to be unbounded by default, you can add the `#[pallet::without_storage_info]` attribute.
 
 **Docs**
 

--- a/v3/docs/03-runtime/b-macros/index.mdx
+++ b/v3/docs/03-runtime/b-macros/index.mdx
@@ -191,8 +191,7 @@ pub struct Pallet<T>(_);
 
 **When to use**
 
-This attribute is now a no_op. It is now assumed by default that all of the pallet storage items are bounded (i.e. have a fixed size).
-You should not need to use this attribute.
+This attribute no longer exists. `generate_storage_info` is now assumed by default: all pallet storage items are expected to be bounded (i.e. have a fixed size).
 
 **What it does**
 


### PR DESCRIPTION
`#[pallet::generate_storage_info]` is now defaulted.