### PR TITLE
Update runtime -> testing `run_to_block` example

### DIFF
--- a/v3/docs/03-runtime/k-testing/index.mdx
+++ b/v3/docs/03-runtime/k-testing/index.mdx
@@ -162,7 +162,7 @@ future maintenance.
 ```rust
 fn run_to_block(n: u64) {
 	while System::block_number() < n {
-		if System::block_number() > 1 {
+		if System::block_number() > 0 {
 			ExamplePallet::on_finalize(System::block_number());
 			System::on_finalize(System::block_number());
 		}


### PR DESCRIPTION
This addresses #931