### PR TITLE
Update sp-io cargo.toml dependency branch version

### DIFF
--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -255,7 +255,7 @@ Just like the [helper files](https://github.com/substrate-developer-hub/substrat
    Ensure that this is declared as a dependency in your pallet's `Cargo.toml` file:
 
    ```toml
-   sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
+   sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
    ```
 
 1. Now try running the following command to build your pallet. We won't build the entire chain just yet because we haven't yet implemented the `Currency` type in our runtime.


### PR DESCRIPTION
With the latest node template, if you paste the sp-io dependecy into pallet/template/cargo.toml you will get a "failed to load manifest for dependency" error. Incrementing the branch version from .17 to .18 fixed the issue for me. I have documented the fix here: https://stackoverflow.com/questions/70403605/failed-to-load-manifest-for-dependency/71786336#71786336

This fix will improve the tutorial experience, although it was a good learning experience for me to fix this issue :)