### PR TITLE
tuple notation fell off

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "serve:fresh": "yarn clean; yarn build; yarn serve",
     "fmt": "prettier --config .prettierrc.js --write \"{!**/*.{js,jsx,ts,tsx,json},**/*.{md,mdx}}\"",
     "fmt:code": "prettier --config .prettierrc.js --write \"{**/*.{js,jsx,ts,tsx,json},!**/*.{md,mdx}}\"",
-    "checklinks": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' http://localhost:9000",
-    "checklinks-local": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' --exclude='undefined' http://localhost:9000",
+    "checklinks": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com'  --exclude='/help.github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' http://localhost:9000",
+    "checklinks-local": "yarn blc --filter-level=3 -rof --requests=10 --exclude='/rustdocs' --exclude='/crates.io' --exclude='/fonts.gstatic.com' --exclude='/github.com'  --exclude='/help.github.com' --exclude='/www.nuget.org' --exclude='/www.chicagomanualofstyle.org' --exclude='undefined' http://localhost:9000",
     "lint": "eslint . --ext ts --ext tsx --ext js --ext jsx",
     "lint:tsc": "tsc -p tsconfig.json --noEmit"
   },

--- a/v3/docs/03-runtime/h-weights-and-fees/index.mdx
+++ b/v3/docs/03-runtime/h-weights-and-fees/index.mdx
@@ -188,7 +188,7 @@ otherwise in the weight annotation, a dispatch is `Normal`. The developer can sp
 dispatchable uses another class like this:
 
 ```rust
-#[pallet::weight(100_000, DispatchClass::Operational)]
+#[pallet::weight((100_000, DispatchClass::Operational))]
 fn my_dispatchable() {
     // ...
 }
@@ -198,7 +198,7 @@ This tuple notation also allows specifying a final argument that determines whet
 is charged based on the annotated weight. When not defined otherwise, `Pays::Yes` is assumed:
 
 ```rust
-#[pallet::weight(100_000, DispatchClass::Normal, Pays::No)]
+#[pallet::weight((100_000, DispatchClass::Normal, Pays::No))]
 fn my_dispatchable() {
     // ...
 }


### PR DESCRIPTION
The tuple is required if more than one argument is specified. Looks like it was there once but maybe someone did not realise that the brackets were indeed supposed to be there.