### PR TITLE
Add `scale-ts` to the list of implementations

### DIFF
--- a/v3/docs/07-advanced/b-scale-codec/index.mdx
+++ b/v3/docs/07-advanced/b-scale-codec/index.mdx
@@ -201,6 +201,7 @@ that is written in Rust and maintained by Parity Technologies.
 - C: [`MatthewDarnell/cScale`](https://github.com/MatthewDarnell/cScale)
 - C++: [`soramitsu/scale-codec-cpp`](https://github.com/soramitsu/scale-codec-cpp)
 - JavaScript: [`polkadot-js/api`](https://github.com/polkadot-js/api)
+- TypeScript: [`scale-ts`](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts)
 - AssemblyScript: [`LimeChain/as-scale-codec`](https://github.com/LimeChain/as-scale-codec)
 - Haskell: [`airalab/hs-web3`](https://github.com/airalab/hs-web3/tree/master/packages/scale)
 - Java: [`emeraldpay/polkaj`](https://github.com/emeraldpay/polkaj)


### PR DESCRIPTION
Hi! I've been working on [this SCALE Codec TS implementation](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts) for the last 5 months and I think that now it's mature enough to be a worthy addition to the list of SCALE Codec implementations.