### PR TITLE
Add example for onboarding to Rococo

### DIFF
--- a/v3/tutorials/09-cumulus/d-rococo/index.mdx
+++ b/v3/tutorials/09-cumulus/d-rococo/index.mdx
@@ -53,19 +53,19 @@ To get started with registering your chain as a parathread:
 
 1. Reserve a unique para ID. You will be assigned to the next available ID.
 
-![paraid-reserve.png](../../../../src/images/tutorials/09-cumulus/paraid-reserve.png)
+   ![paraid-reserve.png](../../../../src/images/tutorials/09-cumulus/paraid-reserve.png)
 
 1. After successfully reserving your para ID, you can now register as a **parathread**.
 
-![register-parathread.png](../../../../src/images/tutorials/09-cumulus/register-parathread.png)
+   ![register-parathread.png](../../../../src/images/tutorials/09-cumulus/register-parathread.png)
 
 1. Once your extrinsic succeeds, you will see a `registrar.Registered` event emitted.
 
-![parathread-register-success.png](../../../../src/images/tutorials/09-cumulus/parathread-register-success.png)
+   ![parathread-register-success.png](../../../../src/images/tutorials/09-cumulus/parathread-register-success.png)
 
 1. Go to the [Parachains -> Parathreads](https://polkadot.js.org/apps/#/parachains/parathreads) page and you will see that your parathread registration is **Onboarding**:
 
-![parathread-onboarding.png](../../../../src/images/tutorials/09-cumulus/parathread-onboarding.png)
+   ![parathread-onboarding.png](../../../../src/images/tutorials/09-cumulus/parathread-onboarding.png)
 
 After the extrinsic succeeds, it takes 2 sessions for the chain to fully onboard as a parathread.
 
@@ -73,7 +73,7 @@ After the extrinsic succeeds, it takes 2 sessions for the chain to fully onboard
 
 Once the parachain is active as a parathread, the related project team should [open a request](https://github.com/paritytech/subport/issues/new?assignees=&labels=Rococo&template=rococo.yaml) for either a **permanent** or a **temporary parachain slot** on Rococo.
 
-- **Permanent slots** are parachain slots assigned to teams who currently have a parachain slot on Polkadot (following a successful slot lease auction) and thus have the needs for continuously testing their codebase for compatibility with the latest bleeding edge features in a real-world live environment (Rococo).
+- **Permanent slots** are parachain slots assigned to teams who currently have a parachain slot on Polkadot or Kusama (following a successful slot lease auction) and thus have the needs for continuously testing their codebase for compatibility with the latest bleeding edge features in a real-world live environment (Rococo).
   There is a limited number of permanent slots made available (see note below).
 
 - **Temporary slots** are parachain slots that are dynamically allocated in a continuous rollover manner.
@@ -98,19 +98,27 @@ Using an account with the `AssignSlotOrigin` origin, follow these steps to assig
 1. Select the account with enough ROC balance that you wish to use to submit a transaction with.
 1. Select the `assignedSlots` pallet.
 1. Choose the `assignTempParachainSlot` function.
-1. Insert your reserved para ID. Make sure this matches the one you reserved from the previous section!
+1. Insert your reserved para ID. Make sure this matches the one you reserved from the previous section.
 1. Select `Current` for the `LeasePeriodStart`. If the current slot is full, you will be assigned the next available slot.
 1. Sign and submit the transaction.
 
 Given a period lease duration of 1 day, the current settings for assigned parachain slots on Rococo are (at the time of writing):
 
-- **Permanent slot least duration**: 1 year (365 days)
-- **Temporary slot least duration**: 3 days
+- **Permanent slot lease duration**: 1 year (365 days)
+- **Temporary slot lease duration**: 3 days
 - **Maximum number of permanent slots**: up to 25 permanent slots
 - **Maximum number of temporary slots**: up to 20 temporary slots
 - **Maximum temporary slots allocated per leased period**: up to 5 temporary slots per 3-day temporary lease periods
 
 These are subject to change, based on the needs of the community.
+
+Here's an example with parathreads `3000`-`3005` registered for a temporary slot (including chain spec and Wasm blob), starting at lease period 0:
+
+* On the first lease day (period 0), all parathreads `3000`-`3005` will onboard as parachains and remain onboarded for 3 lease periods (3 days).
+* At the start of the 4th lease day (period 4), parachains `3000` - `3005` will automatically get off-boarded and become parathreads again. Following this, the next batch of parathreads registered with IDs `3006`-`3010` will be onboarded as a parachain for 3 days if present.
+* At the start of the 7th lease day (period 7), parachains with IDs `3006`-`3010` will be downgraded to parathreads and the next batch of registered parathreads `3011`-`3015` will automatically get onboarded as parachains for 3 days.
+* At the start of the 10th lease day (period 10), parachains `3011`-`3015` get off-boarded and become parathreads again.
+* Assuming there's no newly registered parathreads for temporary slots, parathread `3000`-`3005` will be automatically onboarded as a parachain and the rotation of slots starts over.
 
 🎉**_Congratulations!_**🎉
 

--- a/v3/tutorials/09-cumulus/d-rococo/index.mdx
+++ b/v3/tutorials/09-cumulus/d-rococo/index.mdx
@@ -112,13 +112,15 @@ Given a period lease duration of 1 day, the current settings for assigned parach
 
 These are subject to change, based on the needs of the community.
 
-Here's an example with parathreads `3000`-`3005` registered for a temporary slot (including chain spec and Wasm blob), starting at lease period 0:
+Here's an example with parathreads `3000`-`3010` registered for a temporary slot (including chain spec and Wasm blob), starting at lease period 0:
 
 * On the first lease day (period 0), all parathreads `3000`-`3005` will onboard as parachains and remain onboarded for 3 lease periods (3 days).
-* At the start of the 4th lease day (period 4), parachains `3000` - `3005` will automatically get off-boarded and become parathreads again. Following this, the next batch of parathreads registered with IDs `3006`-`3010` will be onboarded as a parachain for 3 days if present.
-* At the start of the 7th lease day (period 7), parachains with IDs `3006`-`3010` will be downgraded to parathreads and the next batch of registered parathreads `3011`-`3015` will automatically get onboarded as parachains for 3 days.
-* At the start of the 10th lease day (period 10), parachains `3011`-`3015` get off-boarded and become parathreads again.
-* Assuming there's no newly registered parathreads for temporary slots, parathread `3000`-`3005` will be automatically onboarded as a parachain and the rotation of slots starts over.
+At the end of lease period 3, parachains with IDs `3000` - `3005` will automatically be offboarded and will become parathreads again.
+* At the start of the 4th lease day (period 4), the next batch of parathreads registered with IDs `3006`-`3010` will be onboarded as a parachain for 3 days.
+Then by the end of lease period 6, parachains with IDs `3006` - `3010` wbe offboarded and will become parathreads again.
+* At the start of the 7th lease day (period 7), the next batch of registered parathreads to onboard will be `3000`-`3005`, which will automatically get onboarded as parachains for 3 days. And the cycle repeats.
+
+If you are interested in discovering how this lease management is done, pelase check the [source](https://github.com/paritytech/polkadot/blob/master/runtime/common/src/assigned_slots.rs)
 
 🎉**_Congratulations!_**🎉
 


### PR DESCRIPTION
This PR cleans up the guide (number formatting mainly) and adds an example clarifying the process of participating in the temporary slot system.