### PR TITLE
Add missing error type KittyExists to Error enum

### DIFF
--- a/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
+++ b/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
@@ -72,6 +72,8 @@ pub mod pallet {
 		BuyerIsKittyOwner,
 		/// Cannot transfer a kitty to its owner.
 		TransferToSelf,
+		/// This kitty already exists
+		KittyExists,
 		/// Handles checking whether the Kitty exists.
 		KittyNotExist,
 		/// Handles checking that the Kitty is owned by the account transferring, buying or setting a price for it.

--- a/static/assets/tutorials/kitties-tutorial/05-completed.rs
+++ b/static/assets/tutorials/kitties-tutorial/05-completed.rs
@@ -72,6 +72,8 @@ pub mod pallet {
 		BuyerIsKittyOwner,
 		/// Cannot transfer a kitty to its owner.
 		TransferToSelf,
+		/// This kitty already exists
+		KittyExists,
 		/// Handles checking whether the Kitty exists.
 		KittyNotExist,
 		/// Handles checking that the Kitty is owned by the account transferring, buying or setting a price for it.


### PR DESCRIPTION
The error is mentioned in the tutorial and referenced in the code, but missing from the enum in the template