### PR TITLE
Add make to Ubuntu/Debian dependencies

### DIFF
--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -27,7 +27,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev pkg-config
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev make pkg-config
 ```
 
 ### Arch Linux


### PR DESCRIPTION
On a fresh Ubuntu 20.04 machine, I saw build failures for the substrate node template. Eventually I found this [StackExchange question](https://substrate.stackexchange.com/questions/1454/failed-to-compile-on-linux/1464#1464), which showed that `make` was not installed. Apparently it doesn't come preinstalled, at least in Ubuntu 20.04.