### PR TITLE
Update obsolete migration label and link

### DIFF
--- a/v3/docs/03-runtime/m-upgrades/index.mdx
+++ b/v3/docs/03-runtime/m-upgrades/index.mdx
@@ -133,7 +133,7 @@ any [extrinsics or even the `on_initialize` function](/v3/concepts/execution#exe
 
 Preparing for a storage migration means understanding the changes that are defined by a runtime
 upgrade. The Substrate repository uses
-[the `D1-runtime-migration` label](https://github.com/paritytech/substrate/pulls?q=is%3Apr+label%3AD1-runtime-migration)
+[the `E1-runtimemigration` label](https://github.com/paritytech/substrate/pulls?q=is%3Apr+label%3AE1-runtimemigration)
 to designate such changes.
 
 ### Writing a migration


### PR DESCRIPTION
The label "D1-runtime-migration" is changed to "E1-runtimemigration".