### PR TITLE
Additional build dependency for Debian/ubuntu/WSL

### DIFF
--- a/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
+++ b/v3/tutorials/01-create-your-first-substrate-chain/index.mdx
@@ -112,14 +112,14 @@ To install required packages on macOS or Linux:
 
 1. Locate your operating system in the following table and run the appropriate commands for your development environment.
 
-| OS               | Installation commands                                                               |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| Ubuntu or Debian | `sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev` |
-| Arch Linux       | `pacman -Syu --needed --noconfirm curl git clang`                                   |
-| Fedora           | `sudo dnf update sudo dnf install clang curl git openssl-devel`                     |
-| OpenSUSE         | `sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel`         |
-| macOS            | `brew update && brew install openssl`                                               |
-| Windows          | Refer to this [installation guide](/v3/getting-started/windows-users).              |
+| OS               | Installation commands                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| Ubuntu or Debian | `sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev make` |
+| Arch Linux       | `pacman -Syu --needed --noconfirm curl git clang`                                        |
+| Fedora           | `sudo dnf update sudo dnf install clang curl git openssl-devel`                          |
+| OpenSUSE         | `sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel`              |
+| macOS            | `brew update && brew install openssl`                                                    |
+| Windows          | Refer to this [installation guide](/v3/getting-started/windows-users).                   |
 
 If you are using macOS and do not have Homebrew installed, run the following command to install Homebrew:
 


### PR DESCRIPTION
For building the node template on Debian/ubuntu/WSL the make package is required. The ttikv-jemalloc-sys v0.4.3+5.2.1-patched.2 crate now requires the make tool to compile itself and thus the node template. 

I have tested this with ubuntu 22.04 LTS and WSL2 on Windows 11.