### PR TITLE
Add `soramitsu/scale-codec-js-library`

### DIFF
--- a/v3/docs/07-advanced/b-scale-codec/index.mdx
+++ b/v3/docs/07-advanced/b-scale-codec/index.mdx
@@ -200,8 +200,10 @@ that is written in Rust and maintained by Parity Technologies.
 - Golang: [`itering/scale.go`](https://github.com/itering/scale.go)
 - C: [`MatthewDarnell/cScale`](https://github.com/MatthewDarnell/cScale)
 - C++: [`soramitsu/scale-codec-cpp`](https://github.com/soramitsu/scale-codec-cpp)
-- JavaScript: [`polkadot-js/api`](https://github.com/polkadot-js/api)
-- TypeScript: [`scale-ts`](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts)
+- JavaScript / TypeScript:
+  - [`polkadot-js/api`](https://github.com/polkadot-js/api)
+  - [`scale-ts`](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts)
+  - [`soramitsu/scale-codec-js-library`](https://github.com/soramitsu/scale-codec-js-library)
 - AssemblyScript: [`LimeChain/as-scale-codec`](https://github.com/LimeChain/as-scale-codec)
 - Haskell: [`airalab/hs-web3`](https://github.com/airalab/hs-web3/tree/master/packages/scale)
 - Java: [`emeraldpay/polkaj`](https://github.com/emeraldpay/polkaj)


### PR DESCRIPTION
## Proposal description

There is a list of SCALE codec implementations. I propose to append [soramitsu/scale-codec-js-library](https://github.com/soramitsu/scale-codec-js-library) into it. This project has a core library and a compiler for it. The whole stack is used in [Iroha 2 JavaScript SDK](https://github.com/hyperledger/iroha-javascript/tree/iroha2/packages/data-model). It is well-tested, but it needs more real-life usage experience to become better. I hope adding it to the implementations list might help with it.

Probably it is **the most performant** and **the most type-safe** JS implementation.

See its [online documentation](https://soramitsu.github.io/scale-codec-js-library/).