### PR TITLE
fix 1032

### DIFF
--- a/v3/how-to-guides/02-pallet-design/a-add-contracts-pallet/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/a-add-contracts-pallet/index.mdx
@@ -56,21 +56,21 @@ Implement the Contracts pallet [configuration traits][contracts-config-rustdocs]
 
    ```rust
    /* --snip-- */
-   Contracts: pallet_contracts::{Pallet, Call, Config<T>, Storage, Event<T>},
-   /* --snip-- */
-   ```
-
-   For example, the following shows how the parameter type, `DeletionQueueDepth`, should be added:
-
-   ```rust
-   parameter_types! {
-   	/* --snip-- */
+   	parameter_types! {
+   	pub const DepositPerItem: Balance = deposit(1, 0);
+   	pub const DepositPerByte: Balance = deposit(0, 1);
+   	// The lazy deletion runs inside on_initialize.
+   	pub DeletionWeightLimit: Weight = AVERAGE_ON_INITIALIZE_RATIO *
+   		RuntimeBlockWeights::get().max_block;
+   	// The weight needed for decoding the queue should be less or equal than a fifth
+   	// of the overall weight dedicated to the lazy deletion.
    	pub DeletionQueueDepth: u32 = ((DeletionWeightLimit::get() / (
-   		<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(1) -
-   		<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(0)
+   			<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(1) -
+   			<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(0)
    		)) / 5) as u32;
-   		/* --snip-- */
+   	pub Schedule: pallet_contracts::Schedule<Runtime> = Default::default();
    	}
+   /* --snip-- */
    ```
 
    Notice how the above parameter type depends on `WeightInfo`. This requires you to add the following to the top of `runtime/src/lib.rs`:

--- a/v3/how-to-guides/02-pallet-design/a-add-contracts-pallet/index.mdx
+++ b/v3/how-to-guides/02-pallet-design/a-add-contracts-pallet/index.mdx
@@ -56,9 +56,12 @@ Implement the Contracts pallet [configuration traits][contracts-config-rustdocs]
 
    ```rust
    /* --snip-- */
-   	parameter_types! {
-   	pub const DepositPerItem: Balance = deposit(1, 0);
-   	pub const DepositPerByte: Balance = deposit(0, 1);
+   parameter_types! {
+   	pub ContractDeposit: Balance = deposit(
+   		1,
+   		<pallet_contracts::Pallet<Runtime>>::contract_info_size(),
+   	);
+   	pub const MaxValueSize: u32 = 16 * 1024;
    	// The lazy deletion runs inside on_initialize.
    	pub DeletionWeightLimit: Weight = AVERAGE_ON_INITIALIZE_RATIO *
    		RuntimeBlockWeights::get().max_block;
@@ -69,7 +72,7 @@ Implement the Contracts pallet [configuration traits][contracts-config-rustdocs]
    			<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(0)
    		)) / 5) as u32;
    	pub Schedule: pallet_contracts::Schedule<Runtime> = Default::default();
-   	}
+   }
    /* --snip-- */
    ```
 


### PR DESCRIPTION
Closes #1032 

Reference:
https://github.com/paritytech/substrate/blob/632b32300eb9376767c2ae7b38e79b3f7f5329b1/bin/node/runtime/src/lib.rs#L887-L903
```rust
parameter_types! {
	pub ContractDeposit: Balance = deposit(
		1,
		<pallet_contracts::Pallet<Runtime>>::contract_info_size(),
	);
	pub const MaxValueSize: u32 = 16 * 1024;
	// The lazy deletion runs inside on_initialize.
	pub DeletionWeightLimit: Weight = AVERAGE_ON_INITIALIZE_RATIO *
		RuntimeBlockWeights::get().max_block;
	// The weight needed for decoding the queue should be less or equal than a fifth
	// of the overall weight dedicated to the lazy deletion.
	pub DeletionQueueDepth: u32 = ((DeletionWeightLimit::get() / (
			<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(1) -
			<Runtime as pallet_contracts::Config>::WeightInfo::on_initialize_per_queue_item(0)
		)) / 5) as u32;
	pub Schedule: pallet_contracts::Schedule<Runtime> = Default::default();
}
```