### PR TITLE
add make as dep

### DIFF
--- a/v3/docs/01-getting-started/c-installation/index.mdx
+++ b/v3/docs/01-getting-started/c-installation/index.mdx
@@ -27,7 +27,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y git clang curl libssl-dev llvm libudev-dev pkg-config
+sudo apt install -y git clang curl libssl-dev llvm libudev-dev pkg-config make
 ```
 
 ### Arch Linux
@@ -35,7 +35,7 @@ sudo apt install -y git clang curl libssl-dev llvm libudev-dev pkg-config
 Run these commands from a terminal:
 
 ```bash
-pacman -Syu --needed --noconfirm curl git clang
+pacman -Syu --needed --noconfirm curl git clang make
 ```
 
 ### Fedora
@@ -44,7 +44,7 @@ Run these commands from a terminal:
 
 ```bash
 sudo dnf update
-sudo dnf install clang curl git openssl-devel
+sudo dnf install clang curl git openssl-devel make
 ```
 
 ### OpenSUSE
@@ -52,7 +52,7 @@ sudo dnf install clang curl git openssl-devel
 Run these commands from a terminal:
 
 ```bash
-sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel
+sudo zypper install clang curl git openssl-devel llvm-devel libudev-devel make
 ```
 
 ### macOS


### PR DESCRIPTION
Adds `make` based on many reports of it being needed on WSL2 and Ubuntu 22.04 LTS