### PR TITLE
kitties tutorial: fix sp_io import

### DIFF
--- a/static/assets/tutorials/kitties-tutorial/01-basic-setup.rs
+++ b/static/assets/tutorials/kitties-tutorial/01-basic-setup.rs
@@ -7,9 +7,8 @@ pub mod pallet {
     use frame_support::{sp_runtime::traits::{Hash, Zero},
                         dispatch::{DispatchResultWithPostInfo, DispatchResult},
                         traits::{Currency, ExistenceRequirement, Randomness},
-                        pallet_prelude::*};
+                        pallet_prelude::*, sp_io::hashing::blake2_128};
     use frame_system::pallet_prelude::*;
-    use sp_io::hashing::blake2_128;
 
     // TODO Part II: Struct for holding Kitty information.
 

--- a/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
+++ b/static/assets/tutorials/kitties-tutorial/02-create-kitties.rs
@@ -9,9 +9,9 @@ pub mod pallet {
 	use frame_support::{
 		sp_runtime::traits::Hash,
 		traits::{ Randomness, Currency, tokens::ExistenceRequirement },
-		transactional
+		transactional,
+		sp_io::hashing::blake2_128,
 	};
-	use sp_io::hashing::blake2_128;
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]

--- a/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
+++ b/static/assets/tutorials/kitties-tutorial/03-dispatchables-and-events.rs
@@ -9,9 +9,8 @@ pub mod pallet {
 	use frame_support::{
 		sp_runtime::traits::Hash,
 		traits::{ Randomness, Currency, tokens::ExistenceRequirement },
-		transactional
+		transactional, sp_io::hashing::blake2_128,
 	};
-	use sp_io::hashing::blake2_128;
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]

--- a/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
+++ b/static/assets/tutorials/kitties-tutorial/04-interacting-functions.rs
@@ -9,9 +9,9 @@ pub mod pallet {
 	use frame_support::{
 		sp_runtime::traits::Hash,
 		traits::{ Randomness, Currency, tokens::ExistenceRequirement },
-		transactional
+		transactional,
+		sp_io::hashing::blake2_128,
 	};
-	use sp_io::hashing::blake2_128;
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]

--- a/static/assets/tutorials/kitties-tutorial/05-completed.rs
+++ b/static/assets/tutorials/kitties-tutorial/05-completed.rs
@@ -9,9 +9,9 @@ pub mod pallet {
 	use frame_support::{
 		sp_runtime::traits::Hash,
 		traits::{ Randomness, Currency, tokens::ExistenceRequirement },
-		transactional
+		transactional,
+		sp_io::hashing::blake2_128,
 	};
-	use sp_io::hashing::blake2_128;
 	use scale_info::TypeInfo;
 
 	#[cfg(feature = "std")]

--- a/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
+++ b/v3/tutorials/11-kitties-workshop/a-kitties-node/index.mdx
@@ -182,10 +182,9 @@ Just like the [helper files](https://github.com/substrate-developer-hub/substrat
    		sp_runtime::traits::{Hash, Zero},
    		dispatch::{DispatchResultWithPostInfo, DispatchResult},
    		traits::{Currency, ExistenceRequirement, Randomness},
-   		pallet_prelude::*
+   		pallet_prelude::*, sp_io::hashing::blake2_128,
    	};
    	use frame_system::pallet_prelude::*;
-   	use sp_io::hashing::blake2_128;
 
    	// TODO Part II: Struct for holding Kitty information.
 


### PR DESCRIPTION
importing `sp_io::hashing::blake2_128` needs to happend inside `frame_support`.
all the template files were importing outside, which generates
```
error[E0433]: failed to resolve: use of undeclared crate or module `sp_io`
  --> pallets/kitties/src/lib.rs:12:9
   |
12 |     use sp_io::hashing::blake2_128;
   |         ^^^^^ use of undeclared crate or module `sp_io`
```