### PR TITLE
fix benchmarking command

### DIFF
--- a/content/md/en/docs/reference/how-to-guides/weights/add-benchmarks.md
+++ b/content/md/en/docs/reference/how-to-guides/weights/add-benchmarks.md
@@ -187,7 +187,7 @@ Execute the following command to run standard benchmarking for your `pallet_you_
     --execution wasm \
     --wasm-execution compiled \
     --pallet pallet_you_crated \
-    --extrinsic '\*' \
+    --extrinsic '*' \
     --steps 20 \
     --repeat 10 \
     --json-file=raw.json \


### PR DESCRIPTION
InvArch had problems with copy-pasting from the [benchmarking example](https://docs.substrate.io/v3/runtime/benchmarking/#example).

` --extrinsic '\*'` leads to `Error: Input("No benchmarks found which match your input.")`
the correct is ` --extrinsic '*'`

duplicate of https://github.com/substrate-developer-hub/substrate-docs/pull/1052