### PR TITLE
fix benchmarking subcommand

### DIFF
--- a/content/md/en/docs/reference/how-to-guides/weights/add-benchmarks.md
+++ b/content/md/en/docs/reference/how-to-guides/weights/add-benchmarks.md
@@ -182,7 +182,7 @@ The Benchmarking CLI has a lot of options which can help you automate your bench
 Execute the following command to run standard benchmarking for your `pallet_you_created`:
 
 ```bash
-./target/release/node-template benchmark \
+./target/release/node-template benchmark pallet \
     --chain dev \
     --execution wasm \
     --wasm-execution compiled \


### PR DESCRIPTION
since https://github.com/paritytech/substrate/pull/11164 the benchmarking CLI has changed
now it needs to call `benchmark pallet` instead of just `benchmark`