### PR TITLE
Correct link underline color in banner

### DIFF
--- a/src/styles/tailwind-custom.css
+++ b/src/styles/tailwind-custom.css
@@ -210,7 +210,13 @@ div[aria-label='animation'] {
 .banner a {
   @apply text-substrateDarkThemeBlue dark:text-substrateBlue;
 }
+
+.banner a::after {
+  @apply bg-substrateDarkThemeBlue dark:bg-substrateBlue;
+}
+
 /* Nav Icons */
+
 nav ul li span svg {
   @apply dark:text-substrateDarkThemeBlue;
 }


### PR DESCRIPTION
Since the banner has inverted background colors from the site's general color modes, if there are any links in the banner text the link underline appears in the wrong/opposite colors. This is the fix for that.