### PR TITLE
hacky fix to display html file and link to it correctly

### DIFF
--- a/content/md/en/docs/quick-start/index.md
+++ b/content/md/en/docs/quick-start/index.md
@@ -113,11 +113,6 @@ Before you begin, verify the following:
    This following `index.html` is a simple example of how to use JavaScript, the Polkadot-JS API, and HTML to get an account balance.
 
 
-
-   <iframe id="someframe" width="100%" height="400px" src="../examples/index.html"></iframe>
-
-
-
    ```html
    <!DOCTYPE html>
    <html>

--- a/content/md/en/docs/quick-start/index.md
+++ b/content/md/en/docs/quick-start/index.md
@@ -112,6 +112,12 @@ Before you begin, verify the following:
    
    This following `index.html` is a simple example of how to use JavaScript, the Polkadot-JS API, and HTML to get an account balance.
 
+
+
+   <iframe id="someframe" width="100%" height="400px" src="../examples/index.html"></iframe>
+
+
+
    ```html
    <!DOCTYPE html>
    <html>
@@ -170,7 +176,7 @@ Before you begin, verify the following:
    </html>
    ```
 
-1. Open the [index.html](/examples/quickstart/index.html) file in a web browser.
+1. Open the <a className="noTrailingSlash" href="/examples/index.html">index.html</a> file in a web browser.
 
 1. Copy and paste the SS58 Address for the `Alice` account in the input field, then click **Get Balance**.
 

--- a/src/components/default/Link.js
+++ b/src/components/default/Link.js
@@ -44,6 +44,10 @@ const addTrailingSlash = uri => {
   // add slash if missing
   uri = addSlash(uri);
 
+  if (uri === '/examples/index.html/') {
+    return uri.slice(0, -1);
+  }
+
   return uri + search + hash;
 };
 

--- a/src/hooks/use-active-id.js
+++ b/src/hooks/use-active-id.js
@@ -16,7 +16,9 @@ export default function useActiveId(itemIds) {
     );
 
     itemIds.forEach(id => {
-      observer.observe(document.getElementById(id));
+      if (observer.type === Element) {
+        observer.observe(document.getElementById(id));
+      }
     });
 
     return () => {

--- a/static/examples/index.html
+++ b/static/examples/index.html
@@ -31,10 +31,10 @@
       <p class="output">Balance: <span id="polkadot-balance">Not Connected</span></p>
     </main>
   
-    <script src="https://unpkg.com/@polkadot/util/bundle-polkadot-util.js" defer></script>
-    <script src="https://unpkg.com/@polkadot/util-crypto/bundle-polkadot-util-crypto.js" defer></script>
-    <script src="https://unpkg.com/@polkadot/types/bundle-polkadot-types.js" defer></script>
-    <script src="https://unpkg.com/@polkadot/api/bundle-polkadot-api.js" defer></script>
+    <script src="https://unpkg.com/@polkadot/util/bundle-polkadot-util.js"></script>
+    <script src="https://unpkg.com/@polkadot/util-crypto/bundle-polkadot-util-crypto.js"></script>
+    <script src="https://unpkg.com/@polkadot/types/bundle-polkadot-types.js"></script>
+    <script src="https://unpkg.com/@polkadot/api/bundle-polkadot-api.js"></script>
   
     <script>
       async function GetBalance() {


### PR DESCRIPTION
This is a fix for the issues with linking to a static html file within this markdown website.

I do not think that this should be merged as I think it is quite hacky and presents an issue.

The real question underlying the issue of this example .html file and its contents as far as I can see is:

**If we want to display custom components side by side with their code, how do we do so?**

The solution presented here works but I am very sure it is not the best we can do.