### PR TITLE
Should use `compressed` wasm.

### DIFF
--- a/content/md/en/docs/tutorials/get-started/forkless-upgrade.md
+++ b/content/md/en/docs/tutorials/get-started/forkless-upgrade.md
@@ -209,7 +209,7 @@ To upgrade the runtime:
 
 1. Select `file upload`, then select or drag and drop the WebAssembly file that you generated for the runtime.
 
-   For example, navigate to select the `target/release/wbuild/node-template-runtime/node_template_runtime.compact.wasm` file.
+   For example, navigate to select the `target/release/wbuild/node-template-runtime/node_template_runtime.compact.compressed.wasm` file.
 
    Leave the `_weight` parameter with the default of `0`.
 


### PR DESCRIPTION
Should use `compressed` wasm.

We also need to update the screenshot images.