### PR TITLE
Fix substrate-node-temple update tutorial  can't compile

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
@@ -71,7 +71,7 @@ To add the dependencies for the Nicks pallet to the runtime:
    [dependencies.pallet-nicks]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'monthly-2021-10'
+   branch = "polkadot-v0.9.24"
    version = '4.0.0-dev'
    ```
 

--- a/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
@@ -41,14 +41,10 @@ To import the `pallet-contracts` crate:
    [dependencies.pallet-contracts]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'latest'
-   version = '4.0.0-dev'
 
    [dependencies.pallet-contracts-primitives]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'latest'
-   version = '4.0.0-dev'
    ```
 
 1. Add the Contracts pallet to the list of `std` features so that its features are included when the runtime is built as a native Rust binary.


### PR DESCRIPTION
Fix substrate-node-temple update but tutorial can't compile