### PR TITLE
Update to polkadot-v0.9.26 throughout && rm latest tag 

### DIFF
--- a/content/md/en/docs/main-docs/build/build-process.md
+++ b/content/md/en/docs/main-docs/build/build-process.md
@@ -19,8 +19,8 @@ You can see this when running `cargo tree -i node-template-runtime` from the ter
 
 ```bash
 # Displays all packages that depend on the node-template-runtime package.
-node-template-runtime devhub/latest (...)
-└── node-template devhub/latest (...)
+node-template-runtime devhub/polkadot-v0.9.26 (...)
+└── node-template devhub/polkadot-v0.9.26 (...)
 ```
 
 But how is the Wasm runtime created?

--- a/content/md/en/docs/main-docs/install/linux.md
+++ b/content/md/en/docs/main-docs/install/linux.md
@@ -136,7 +136,7 @@ To compile the Substrate node template:
 1. Clone the node template repository by running the following command:
 
    ```bash
-   git clone --branch latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+   git clone --branch polkadot-v0.9.26 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
 1. Change to the root of the node template directory by running the following command:

--- a/content/md/en/docs/main-docs/install/macos.md
+++ b/content/md/en/docs/main-docs/install/macos.md
@@ -146,7 +146,7 @@ To compile the Substrate node template:
 1. Clone the node template repository by running the following command:
 
    ```bash
-   git clone --branch latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+   git clone --branch polkadot-v0.9.26 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
 1. Change to the root of the node template directory by running the following command:

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -155,7 +155,7 @@ To compile the Substrate node template:
 1. Clone the node template repository by running the following command:
 
    ```bash
-   git clone --branch latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+   git clone --branch polkadot-v0.9.26 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
 1. Change to the root of the node template directory by running the following command:

--- a/content/md/en/docs/quick-start/index.md
+++ b/content/md/en/docs/quick-start/index.md
@@ -7,7 +7,7 @@ keywords:
 All of the Substrate tutorials and how-to guides require you to build and run a Substrate node in your development environment.
 To help you set up a working environment quickly, the [Substrate Developer Hub](https://github.com/substrate-developer-hub/) maintains several _templates_ for you to use.
 
-The Developer Hub snapshot of the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template/releases/tag/latest) includes everything you need to get started with a core set of features.
+The Developer Hub snapshot of the [substrate-node-template](https://github.com/substrate-developer-hub/substrate-node-template/releases/tag/polkadot-v0.9.26) includes everything you need to get started with a core set of features.
 
 This _Quick start_ assumes that you are setting up a development environment for the first time and want to try out running a single blockchain node on your local computer.
 
@@ -30,10 +30,10 @@ Before you begin, verify the following:
 
 ## Build the node template
 
-1. Clone the node template repository using the `latest` tag by running the following command:
+1. Clone the node template repository using the `polkadot-v0.9.26` tag by running the following command:
 
    ```sh
-   git clone --branch latest --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+   git clone --branch polkadot-v0.9.26 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
 1. Change to the root of the cloned directory:

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-http-requests.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-http-requests.md
@@ -92,6 +92,6 @@ The Substrate HTTP library supports the following methods:
 
 ## Examples
 
-- [Example pallet: Offchain worker](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker/src/lib.rs#L571-L625)
+- [Example pallet: Offchain worker](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker/src/lib.rs#L571-L625)
 - [Demo: OCW pallet](https://github.com/jimmychu0807/substrate-offchain-worker-demo/blob/master/pallets/ocw/src/lib.rs#L363-#L401)
 - [Source: Substrate core primitives](https://github.com/paritytech/substrate/blob/master/primitives/runtime/src/offchain/http.rs#L63-L76)

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-indexing.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-indexing.md
@@ -92,7 +92,7 @@ For example: `./target/release/substrate-node --enable-offchain-indexing true`
    ```
 
    The indexing data can be any data type that can be bound by the `Encode`, `Decode`, and `Deserialize` traits.
-   In the above code, data is stored via offchain indexing using the [`offchain_index::set()`](https://paritytech.github.io/substrate/latest/sp_io/offchain_index/fn.set.html) method.
+   In the above code, data is stored via offchain indexing using the [`offchain_index::set()`](https://paritytech.github.io/substrate/master/sp_io/offchain_index/fn.set.html) method.
 
 1. Use the `offchain_worker` hook method to read the data in the offchain workers' database:
 

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-local-storage.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-local-storage.md
@@ -43,7 +43,7 @@ If the cached value is found, offchain worker returns; else it will try to acqui
    }
    ```
 
-   In the above code, a persistent local storage is defined using [`StorageValueRef::persistent()`](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.persistent) which is identified by `pallet::my-storage` key.
+   In the above code, a persistent local storage is defined using [`StorageValueRef::persistent()`](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.persistent) which is identified by `pallet::my-storage` key.
    The key is in a byte array type instead of a `str` type.
    This local storage is persisted and shared across runs of the offchain workers.
 
@@ -61,11 +61,11 @@ If the cached value is found, offchain worker returns; else it will try to acqui
    }
    ```
 
-   The result is fetched using [`get<T: Decode>()`](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.get) function, returning a `Result<Option<T>, StorageRetrievalError>` type.
+   The result is fetched using [`get<T: Decode>()`](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.get) function, returning a `Result<Option<T>, StorageRetrievalError>` type.
    We only care about the case of having a valid value. If yes, return `Ok(())`.
    Note we also need to define the type of the returned value.
 
-   Use [`set()`](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.get) to write to storage and [`mutate<T, E, F>()`](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.mutate) to read and change the storage atomically.
+   Use [`set()`](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.get) to write to storage and [`mutate<T, E, F>()`](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage/struct.StorageValueRef.html#method.mutate) to read and change the storage atomically.
 
 1. If there is no valid value (`None`) or having a `StorageRetrievalError`, proceed to compute the required result and acquire the storage lock.
 
@@ -96,12 +96,12 @@ If the cached value is found, offchain worker returns; else it will try to acqui
    }
    ```
 
-   In the above code snippet, a storage lock is defined with both the [block and time deadline specified](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.with_block_and_time_deadline).
+   In the above code snippet, a storage lock is defined with both the [block and time deadline specified](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.with_block_and_time_deadline).
    This function takes in a lock identifier, block number expiration, and time expiration.
    The above lock expires when it either passes the specified amount of block number or time duration.
-   We can also specify the expiration period with [just the block number](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.with_block_deadline) or [time duration](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.with_deadline).
+   We can also specify the expiration period with [just the block number](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.with_block_deadline) or [time duration](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.with_deadline).
 
-1. Acquire the storage lock using [`.try_lock()`](https://paritytech.github.io/substrate/latest/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.try_lock).
+1. Acquire the storage lock using [`.try_lock()`](https://paritytech.github.io/substrate/master/sp_runtime/offchain/storage_lock/struct.StorageLock.html#method.try_lock).
 
    ```rust
    fn offchain_worker(block_number: T::BlockNumber) {
@@ -155,5 +155,5 @@ If the cached value is found, offchain worker returns; else it will try to acqui
 
 ## Examples
 
-- [**Off-chain worker example pallet** in Substrate](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker/src/lib.rs#L372-L441)
+- [**Off-chain worker example pallet** in Substrate](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker/src/lib.rs#L372-L441)
 - [**OCW pallet** demo](https://github.com/jimmychu0807/substrate-offchain-worker-demo/blob/master/pallets/ocw/src/lib.rs#L299-L342)

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-transactions.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-transactions.md
@@ -41,7 +41,7 @@ For example:
    }
    ```
 
-1. Add the [`CreateSignedTransaction` trait](https://paritytech.github.io/substrate/latest/frame_system/offchain/trait.CreateSignedTransaction.html) to the Config trait for your pallet.
+1. Add the [`CreateSignedTransaction` trait](https://paritytech.github.io/substrate/master/frame_system/offchain/trait.CreateSignedTransaction.html) to the Config trait for your pallet.
    For example, your pallet `Config` trait should look similar to this:
 
    ```rust
@@ -83,7 +83,7 @@ For example:
    }
    ```
 
-   The [`app_crypto` macro](https://paritytech.github.io/substrate/latest/sp_application_crypto/macro.app_crypto.html) declares an account with an sr25519 signature that is identified by `KEY_TYPE`.
+   The [`app_crypto` macro](https://paritytech.github.io/substrate/master/sp_application_crypto/macro.app_crypto.html) declares an account with an sr25519 signature that is identified by `KEY_TYPE`.
    Note that this doesn't create a new account.
    The macro simply declares that a crypto account is available for this pallet.
    You will need to initialize this account in the next step.
@@ -143,7 +143,7 @@ For example:
 
    Because you configured the `Config` trait for this pallet to implement the `CreateSignedTransaction` trait, you also need to implement that trait for the runtime.
 
-   By looking at [`CreateSignedTransaction` Rust docs](https://paritytech.github.io/substrate/latest/frame_system/offchain/trait.CreateSignedTransaction.html), you can see that you only need to implement the function `create_transaction()` for the runtime.
+   By looking at [`CreateSignedTransaction` Rust docs](https://paritytech.github.io/substrate/master/frame_system/offchain/trait.CreateSignedTransaction.html), you can see that you only need to implement the function `create_transaction()` for the runtime.
    In `runtime/src/lib.rs`:
 
    ```rust
@@ -192,7 +192,7 @@ For example:
    - Sign the raw payload with the account public key.
    - Finally, bundle all data up and return a tuple of the call, the caller, its signature, and any signed extension data.
 
-   You can see a full example of the code in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/bin/node/runtime/src/lib.rs).
+   You can see a full example of the code in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/bin/node/runtime/src/lib.rs).
 
 1. Implement `SigningTypes` and `SendTransactionTypes` in the runtime to support submitting transactions, whether they are signed or unsigned.
 
@@ -211,7 +211,7 @@ For example:
    }
    ```
 
-   You can see an example of this implementation in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/bin/node/runtime/src/lib.rs#L1103-L1114).
+   You can see an example of this implementation in the [**Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/bin/node/runtime/src/lib.rs#L1103-L1114).
 
 1. Inject an account for this pallet to own.
    In a development environment (node running with `--dev` flag), this account key is inserted in the `node/src/service.rs` file as follows:
@@ -263,7 +263,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
    }
    ```
 
-   Call the [`validate_unsigned` pallet macro](https://paritytech.github.io/substrate/latest/frame_support/attr.pallet.html#validate-unsigned-palletvalidate_unsigned-optional), then implement the trait as follows:
+   Call the [`validate_unsigned` pallet macro](https://paritytech.github.io/substrate/master/frame_support/attr.pallet.html#validate-unsigned-palletvalidate_unsigned-optional), then implement the trait as follows:
 
    ```rust
    fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
@@ -292,7 +292,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
 
    In this example, users can call the on-chain `extrinsic1` function without a signature, but not any other extrinsics.
 
-   To see a full example of how `ValidateUnsigned` is implemented in a pallet, refer to [`pallet-example-offchain-worker` in **Substrate**](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker/src/lib.rs#L301-L329).
+   To see a full example of how `ValidateUnsigned` is implemented in a pallet, refer to [`pallet-example-offchain-worker` in **Substrate**](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker/src/lib.rs#L301-L329).
 
 1. In the offchain worker function, you can send unsigned transactions as follows:
 
@@ -306,7 +306,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
    		let call = Call::unsigned_extrinsic1 { key: value };
 
    		// `submit_unsigned_transaction` returns a type of `Result<(), ()>`
-   		//	 ref: https://paritytech.github.io/substrate/latest/frame_system/offchain/struct.SubmitTransaction.html
+   		//	 ref: https://paritytech.github.io/substrate/master/frame_system/offchain/struct.SubmitTransaction.html
    		SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
    			.map_err(|_| {
    			log::error!("Failed in offchain_unsigned_tx");
@@ -315,7 +315,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
    }
    ```
 
-   This code prepares the call in the `let call = ...` line, submits the transaction using [`SubmitTransaction::submit_unsigned_transaction`](https://paritytech.github.io/substrate/latest/frame_system/offchain/struct.SubmitTransaction.html), and performs any necessary error handling in the callback function passed in.
+   This code prepares the call in the `let call = ...` line, submits the transaction using [`SubmitTransaction::submit_unsigned_transaction`](https://paritytech.github.io/substrate/master/frame_system/offchain/struct.SubmitTransaction.html), and performs any necessary error handling in the callback function passed in.
 
 1. Enable the `ValidateUnsigned` trait for the pallet in the runtime by adding the `ValidateUnsigned` type to the `construct_runtime` macro.
 
@@ -336,7 +336,7 @@ To enable Substrate to accept certain unsigned transactions, you must implement 
 
 1. Implement the `SendTransactionTypes` trait for the runtime as described in [sending signed transactions](#sending-signed-transactions).
 
-   You can see a full example in [`pallet-example-offchain-worker` in **Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker).
+   You can see a full example in [`pallet-example-offchain-worker` in **Substrate** code base](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker).
 
 ## Sending unsigned transactions with signed payloads
 
@@ -345,13 +345,13 @@ You need to:
 
 - Implement the `ValidateUnsigned` trait for the pallet.
 - Add the `ValidateUnsigned` type to the runtime when using this pallet.
-- Prepare the data structure to be signed—the signed payload—by implementing the [`SignedPayload` trait](https://paritytech.github.io/substrate/latest/frame_system/offchain/trait.SignedPayload.html).
+- Prepare the data structure to be signed—the signed payload—by implementing the [`SignedPayload` trait](https://paritytech.github.io/substrate/master/frame_system/offchain/trait.SignedPayload.html).
 - Send the transaction with the signed payload.
 
 You can refer to the section on [sending unsigned transactions](#sending-unsigned-transactions) for more information about implementing the `ValidateUnsigned` trait and adding the `ValidateUnsigned` type to the runtime.
 The differences between sending unsigned transactions and sending unsigned transactions with signed payload are illustrated in the following code examples.
 
-1. To make your data structure signable, implement the [`SignedPayload` trait](https://paritytech.github.io/substrate/latest/frame_system/offchain/trait.SignedPayload.html).
+1. To make your data structure signable, implement the [`SignedPayload` trait](https://paritytech.github.io/substrate/master/frame_system/offchain/trait.SignedPayload.html).
 
    For example:
 
@@ -369,7 +369,7 @@ The differences between sending unsigned transactions and sending unsigned trans
    }
    ```
 
-   You can also see an example [here](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker/src/lib.rs#L348-L361).
+   You can also see an example [here](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker/src/lib.rs#L348-L361).
 
 1. In your pallet's `offchain_worker` function, call the signer, then the function to send the transaction:
 
@@ -445,9 +445,9 @@ The differences between sending unsigned transactions and sending unsigned trans
    }
    ```
 
-   This example uses [`SignedPayload`](https://paritytech.github.io/substrate/latest/frame_system/offchain/trait.SignedPayload.html) to verify that the public key in the payload has the same signature as the one provided.
+   This example uses [`SignedPayload`](https://paritytech.github.io/substrate/master/frame_system/offchain/trait.SignedPayload.html) to verify that the public key in the payload has the same signature as the one provided.
 
-Refer to the [offchain function call](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker/src/lib.rs#L508-L536) and [the implementation of `ValidateUnsigned`](https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/examples/offchain-worker/src/lib.rs#L305-L329) for a working example of the above.
+Refer to the [offchain function call](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker/src/lib.rs#L508-L536) and [the implementation of `ValidateUnsigned`](https://github.com/paritytech/substrate/blob/polkadot-v0.9.26/frame/examples/offchain-worker/src/lib.rs#L305-L329) for a working example of the above.
 
 You have now seen how you can use offchain workers to send data for on-chain storage using:
 
@@ -457,7 +457,7 @@ You have now seen how you can use offchain workers to send data for on-chain sto
 
 ## Examples
 
-- [Substrate Offchain Worker Example Pallet](https://github.com/paritytech/substrate/tree/polkadot-v0.9.24/frame/examples/offchain-worker)
+- [Substrate Offchain Worker Example Pallet](https://github.com/paritytech/substrate/tree/polkadot-v0.9.26/frame/examples/offchain-worker)
 - [OCW Pallet in Substrate Offchain Worker Demo](https://github.com/jimmychu0807/substrate-offchain-worker-demo/tree/v2.0.0/pallets/ocw)
 
 ## Related material

--- a/content/md/en/docs/reference/how-to-guides/pallet-design/add-contracts-pallet.md
+++ b/content/md/en/docs/reference/how-to-guides/pallet-design/add-contracts-pallet.md
@@ -12,7 +12,7 @@ You can follow similar patterns to add additional FRAME pallets to your runtime,
 
 ## Before you begin
 
-Make sure you have the latest version of the Substrate node template compiled on your computer.
+Make sure you have the latest version (`polkadot-v0.9.26`) of the Substrate node template compiled on your computer.
 If you haven't already done so, see [Build a local blockchain](/tutorials/get-started/build-local-blockchain/).
 
 ## Import the dependencies

--- a/content/md/en/docs/reference/how-to-guides/pallet-design/use-loose-coupling.md
+++ b/content/md/en/docs/reference/how-to-guides/pallet-design/use-loose-coupling.md
@@ -17,7 +17,7 @@ pallet you want to couple to accordingly:
 
 ```toml
 [dependencies]
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.24", version = "4.0.0-dev" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.26", version = "4.0.0-dev" }
 
 # -- snip
 

--- a/content/md/en/docs/reference/how-to-guides/parachains/convert-a-solo-chain.md
+++ b/content/md/en/docs/reference/how-to-guides/parachains/convert-a-solo-chain.md
@@ -45,7 +45,7 @@ There are, however, a few important differences between the two templates that a
 
 #### Parachain info pallet
 
-Parachain template runtime ([`runtime/Cargo.toml`](https://github.com/substrate-developer-hub/substrate-parachain-template/blob/latest/runtime/Cargo.toml)) has integrated [`parachain-info` pallet](https://paritytech.github.io/cumulus/parachain_info/pallet/index.html) in.
+Parachain template runtime ([`runtime/Cargo.toml`](https://github.com/substrate-developer-hub/substrate-parachain-template/blob/polkadot-v0.9.26/runtime/Cargo.toml)) has integrated [`parachain-info` pallet](https://paritytech.github.io/cumulus/parachain_info/pallet/index.html) in.
 This pallet is designed to inject information about the parachain's registration into its own runtime.
 Currently it just injects the `ParaID` that the chain is registered at.
 This allows the runtime to know which cross-chain messages are intended for it.
@@ -54,7 +54,7 @@ This allows the runtime to know which cross-chain messages are intended for it.
 
 Each parachain must supply a `validate_block` function, expressed as a Wasm blob, to the relay chain when registering.
 The node template does not provide this function, but the parachain template does,
-Thanks to cumulus, creating this function for a Substrate runtime is as simple as adding one line of code as shown [at the bottom of the runtime](https://github.com/substrate-developer-hub/substrate-parachain-template/blob/latest/runtime/src/lib.rs#L648-L652):
+Thanks to cumulus, creating this function for a Substrate runtime is as simple as adding one line of code as shown [at the bottom of the runtime](https://github.com/substrate-developer-hub/substrate-parachain-template/blob/polkadot-v0.9.26/runtime/src/lib.rs#L648-L652):
 
 ```rust
 cumulus_pallet_parachain_system::register_validate_block!(
@@ -74,7 +74,7 @@ This is fundamental to Polkadot's architecture and will not change.
 
 #### Service
 
-The collator service ([`node/src/service.rs`](https://github.com/substrate-developer-hub/substrate-parachain-template/blob/latest/node/src/service.rs)) is entirely different from the one of Node template.
+The collator service ([`node/src/service.rs`](https://github.com/substrate-developer-hub/substrate-parachain-template/blob/polkadot-v0.9.26/node/src/service.rs)) is entirely different from the one of Node template.
 While you can find similarities, the structure of the service is much different.
 This new service is the primary change that cumulus provides.
 

--- a/content/md/en/docs/reference/how-to-guides/testing/set-up-basic-tests.md
+++ b/content/md/en/docs/reference/how-to-guides/testing/set-up-basic-tests.md
@@ -17,7 +17,7 @@ This pallet will contain a single function called `add_value`, that takes an ori
 
 Inside `pallet-testing/src`, the first thing we need to do is create two empty files: `mock.rs` and `tests.rs`.
 
-Paste in the contents from [`template/src/mock.rs`](https://github.com/substrate-developer-hub/substrate-node-template/blob/latest/pallets/template/src/mock.rs).
+Paste in the contents from [`template/src/mock.rs`](https://github.com/substrate-developer-hub/substrate-node-template/blob/polkadot-v0.9.26/pallets/template/src/mock.rs).
 We'll use this as boilerplate which we'll customize for our `pallet-testing` pallet.
 
 ## Create a mock runtime to test your pallet

--- a/content/md/en/docs/reference/how-to-guides/tools/use-try-runtime.md
+++ b/content/md/en/docs/reference/how-to-guides/tools/use-try-runtime.md
@@ -29,8 +29,8 @@ Add the FRAME dependency:
 
 ```rust
 [dependencies]
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.24", optional = true }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.24", optional = true }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.26", optional = true }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.26", optional = true }
 
 /* --snip-- */
     std = [
@@ -78,8 +78,8 @@ try-runtime = [
 ]
 
 /* --snip-- */
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.24", optional = true }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.24", optional = true }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.26", optional = true }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-vv0.9.26", optional = true }
 /* --snip-- */
 
 ```

--- a/content/md/en/docs/tutorials/connect-other-chains/local-parachain.md
+++ b/content/md/en/docs/tutorials/connect-other-chains/local-parachain.md
@@ -24,7 +24,7 @@ Before you begin, verify the following:
 
 - You have competed the [Prepare a local parachain testnet](/tutorials/connect-other-chains/local-relay/) tutorial, and have a running local network with no les than two validators.
 - You have the specific software versions defined in the [Prepare a local parachain testnet](/tutorials/connect-other-chains/local-relay/#matching-versions-are-critical) incorporated into your parachain.
-  For example, if you are using [Polkadot `release-v0.9.24`](https://github.com/paritytech/polkadot/tree/release-v0.9.24), use the `polkadot-v0.9.24` version of the [parachain template](https://github.com/substrate-developer-hub/substrate-parachain-template/tree/polkadot-v0.9.24).
+  For example, if you are using [Polkadot `release-v0.9.26`](https://github.com/paritytech/polkadot/tree/release-v0.9.26), use the `polkadot-v0.9.26` version of the [parachain template](https://github.com/substrate-developer-hub/substrate-parachain-template/tree/polkadot-v0.9.26).
 
 ## Build the parachain template
 
@@ -36,7 +36,7 @@ In a new terminal window:
 
 ```bash
 # Clone the parachain template with the correct Polkadot version
-git clone --depth 1 --branch polkadot-v0.9.24 https://github.com/substrate-developer-hub/substrate-parachain-template
+git clone --depth 1 --branch polkadot-v0.9.26 https://github.com/substrate-developer-hub/substrate-parachain-template
 
 # Switch into the parachain template directory
 cd substrate-parachain-template

--- a/content/md/en/docs/tutorials/connect-other-chains/local-relay.md
+++ b/content/md/en/docs/tutorials/connect-other-chains/local-relay.md
@@ -50,8 +50,8 @@ If you don't keep up with relay chain upgrades, it's likely that your network wi
 
 **All tutorials in the docs** have been tested to work with:
 
-- [Polkadot `v0.9.24`](https://github.com/paritytech/polkadot/tree/release-v0.9.24)
-- [Substrate Parachain Template `polkadot-v0.9.24`](https://github.com/substrate-developer-hub/substrate-parachain-template/tree/polkadot-v0.9.24)
+- [Polkadot `v0.9.26`](https://github.com/paritytech/polkadot/tree/release-v0.9.26)
+- [Substrate Parachain Template `polkadot-v0.9.26`](https://github.com/substrate-developer-hub/substrate-parachain-template/tree/polkadot-v0.9.26)
 - [Polkadot-JS Apps `v0.116.2-34 `](https://github.com/polkadot-js/apps/commit/151c4cd75b6eb68ac275d90fd17f98b28b6e57a7).
   It is generally expected that the [hosted Polkadot-JS Apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) should work.
   If you have issues, build and run this UI yourself at this tagged version/commit.
@@ -64,7 +64,7 @@ A slightly modified version of Polkadot's built in `rococo-local` network config
 
 ```bash
 # Clone the Polkadot Repository, with correct version
-git clone --depth 1 --branch release-v0.9.24 https://github.com/paritytech/polkadot.git
+git clone --depth 1 --branch release-v0.9.26 https://github.com/paritytech/polkadot.git
 
 # Switch into the Polkadot directory
 cd polkadot

--- a/content/md/en/docs/tutorials/get-started/build-local-blockchain.md
+++ b/content/md/en/docs/tutorials/get-started/build-local-blockchain.md
@@ -69,10 +69,10 @@ To compile the Substrate node template:
    git clone https://github.com/substrate-developer-hub/substrate-node-template
    ```
 
-1. Change to the root of the node template directory and checkout the `latest` branch by running the following command:
+1. Change to the root of the node template directory and checkout the `polkadot-v0.9.26` branch by running the following command:
 
    ```bash
-   cd substrate-node-template && git checkout latest
+   cd substrate-node-template && git checkout polkadot-v0.9.26
    ```
 
 1. Compile the node template by running the following command:

--- a/content/md/en/docs/tutorials/get-started/forkless-upgrade.md
+++ b/content/md/en/docs/tutorials/get-started/forkless-upgrade.md
@@ -94,7 +94,7 @@ To upgrade the runtime:
    ```toml
    [dependencies]
    ...
-   pallet-scheduler = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+   pallet-scheduler = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ...
    ```
 

--- a/content/md/en/docs/tutorials/get-started/permissioned-network.md
+++ b/content/md/en/docs/tutorials/get-started/permissioned-network.md
@@ -85,10 +85,10 @@ If you have completed previous tutorials, you should have the Substrate node tem
    cd substrate-node-template
    ```
 
-1. Switch to the version of the repository that has the `latest` tag by running the following command:
+1. Switch to the version of the repository that has the `polkadot-v0.9.26` tag by running the following command:
 
    ```bash
-   git checkout latest
+   git checkout polkadot-v0.9.26
    ```
 
    This command checks out the repository in a detached state.

--- a/content/md/en/docs/tutorials/smart-contracts/first-smart-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/first-smart-contract.md
@@ -81,7 +81,7 @@ If you can't download the precompiled node, you can compile it locally with a co
 cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --tag <latest-tag> --force --locked
 ```
 
-You can find the latest tag to use on the [Tags](https://github.com/paritytech/substrate-contracts-node/tags) page.
+You can find the latest tag (`polkadot-v0.9.26` to match the rest of the docs example code versions) to use on the [Tags](https://github.com/paritytech/substrate-contracts-node/tags) page.
 
 ## Install additional packages
 

--- a/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
@@ -30,7 +30,7 @@ Before you begin, verify the following:
 
 - You have configured your environment for Substrate development by installing [Rust and the Rust toolchain](/main-docs/install/rust-builds/).
 
-- You have completed the [Build a local blockchain](/tutorials/get-started/build-local-blockchain/) tutorial and have the Substrate node template from the Developer Hub `latest` branch installed locally.
+- You have completed the [Build a local blockchain](/tutorials/get-started/build-local-blockchain/) tutorial and have the Substrate node template from the Developer Hub `polkadot-v0.9.26` branch installed locally.
 
 - You are generally familiar with software development and using command-line interfaces.
 

--- a/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
@@ -17,11 +17,11 @@ This tutorial focuses less on those common patterns and more on the the settings
 
 Before starting this tutorial, verify the following:
 
-- You have downloaded and compiled the `latest` version of the
-  [Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template/tree/latest).
+- You have downloaded and compiled the `polkadot-v0.9.26` version of the
+  [Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template/tree/polkadot-v0.9.26).
 
 - You have downloaded and installed the
-  [Substrate front-end template](https://github.com/substrate-developer-hub/substrate-node-template/tree/latest) as described in
+  [Substrate front-end template](https://github.com/substrate-developer-hub/substrate-node-template/tree/polkadot-v0.9.26) as described in
   [Build a local blockchain](/tutorials/get-started/build-local-blockchain/).
 
 ## Add the pallet dependencies
@@ -42,7 +42,7 @@ To import the `pallet-contracts` crate:
    For example, add a line similar to the following:
 
    ```toml
-   pallet-contracts = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+   pallet-contracts = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ```
 
 1. Import the `pallet-contracts-primitives` crate to make it available to the node template runtime by adding it to the list of dependencies.
@@ -52,7 +52,7 @@ To import the `pallet-contracts` crate:
    For example, if the compiler found version 6.0.0 for the `pallet-contracts-primitives` crate:
 
    ```toml
-   pallet-contracts-primitives = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+   pallet-contracts-primitives = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ```
 
 1. Add the Contracts pallet to the list of `std` features so that its features are included when the runtime is built as a platform native binary.
@@ -239,7 +239,7 @@ To expose the Contracts RPC API:
    For example:
 
    ```toml
-   pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+   pallet-contracts-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ```
 
 1. Add `pallet-contracts-rpc-runtime-api` to the list of `std` features so that its features are included when the runtime is built as a native binary.
@@ -339,8 +339,8 @@ To add the RPC API extension to the outer node:
    For example:
 
    ```toml
-   pallet-contracts = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-   pallet-contracts-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+   pallet-contracts = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
+   pallet-contracts-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ```
 
    Because you have exposed the runtime API and are now working in code for the outer node, you don't need to use `no_std` configuration, so you don't have to maintain a dedicated `std` list of features.

--- a/content/md/en/docs/tutorials/work-with-pallets/custom-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/custom-pallet.md
@@ -221,8 +221,8 @@ To add the `sp-std` crate to the pallet:
    [dependencies.sp-std]
    default-features = false
    git = 'https://github.com/paritytech/substrate.git'
-   tag = 'monthly-2021-11-1'  # or the latest monthly
-   version = '4.0.0-dev'      # or the latest version
+   tag = 'polkadot-v0.9.26'  # Must *match* the rest of your Substrate deps!
+   version = '4.0.0'
    ```
 
 1. Add the `sp-std` crate to the list of features.


### PR DESCRIPTION
`latest` tag on templates was a foot-gun for users as it wasn't closely maintained, and mis-matching versions on the docs examples leads to bad UX and buggy behavior. 

So from here on we can just do a global find & replace for the version on an update:

- polkadot-v0.9.26
- release-v0.9.26
- 0.9.26

Adjust the above fields to inspect based on the present version in docs to find and replace things. `0.9.26` should be sufficient to update to polkadot-v0.9.27 with find and replace of 0.9.26 -> 0.9.27 for example

I think latter on we can have a more "nice" way of doing this, hopefully releases get a lot better upstream so there is less churn here :crossed_fingers: 