### PR TITLE
delete `generate_storage_info` in tutorial

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/custom-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/custom-pallet.md
@@ -127,7 +127,6 @@ Therefore, the first step is to remove some files and content from the files in 
    	#[pallet::error]   // <-- Step 4. code block will replace this.
    	#[pallet::pallet]
    	#[pallet::generate_store(pub(super) trait Store)]
-   	#[pallet::generate_storage_info]
    	pub struct Pallet<T>(_);
 
    	#[pallet::storage] // <-- Step 5. code block will replace this.


### PR DESCRIPTION
https://substrate.stackexchange.com/questions/3855/use-macros-in-a-custom-pallet-tutorial-doesnt-compile