### PR TITLE
Change tag with branch tutorial

### DIFF
--- a/content/md/en/docs/tutorials/get-started/permissioned-network.md
+++ b/content/md/en/docs/tutorials/get-started/permissioned-network.md
@@ -129,7 +129,7 @@ To add the `node-authorization` pallet to the Substrate runtime:
 
    ```toml
    [dependencies]
-   pallet-node-authorization = { default-features = false, git = "https://github.com/paritytech/substrate.git", tag = "devhub/latest", version = "4.0.0-dev" }
+   pallet-node-authorization = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ```
 
    This line imports the `pallet-node-authorization` crate as a dependency and specifies the following configuration details for the crate:


### PR DESCRIPTION
Change `tag` with `branch` in the tutorial and set the line with the default order used in the template.