### PR TITLE
Correct typos in accounts-addresses-keys.md

### DIFF
--- a/content/md/en/docs/main-docs/fundamentals/accounts-addresses-keys.md
+++ b/content/md/en/docs/main-docs/fundamentals/accounts-addresses-keys.md
@@ -15,7 +15,7 @@ How you implement and use accounts is entirely up to you as a blockchain or para
 
 In general, every account has an owner who possesses a public and private key pair.
 The **private key** is a cryptographically-secure sequence of randomly-generated numbers. For human readability, the private key generates a random sequence of words called a **secret seed phrase** or **mnemonic**.
-This secret seed phrase can be used an account owner to recover access to an account if the private key is lost.
+This secret seed phrase can be used by an account owner to recover access to an account if the private key is lost.
 
 For most networks, the **public key** associated with an account is how that account is identified on the network and is used as the destination address for transactions.
 However, Substrate-based chains use the underlying public key to derive one or more **public addresses**.
@@ -26,14 +26,14 @@ Instead of using the public key directly, Substrate allows you generate multiple
 Substrate enables you to use a single public key to derive multiple addresses so you can interact with multiple chains without creating separate public and private key pairs for each network.
 By default, the addresses associated with the public key for an account use the Substrate [**SS58 address format**](/reference/glossary/#ss58-address-format).
 This address format is based on [base-58 encoding](https://tools.ietf.org/id/draft-msporny-base58-01.html).
-TIn addition to allowing you to derive multiple addresses from the same public key, base-58 encoding has the following benefits:
+In addition to allowing you to derive multiple addresses from the same public key, base-58 encoding has the following benefits:
 
 - Encoded addresses consist of 58 alphanumeric characters.
 - The alphanumeric string omits characters—such as `0`, `O`, `I`, and `l`—that can be difficult to distinguish from each other in a string.
 - Network information—for example, a network-specific prefix—can be encoded in the address.
 - Input errors can be detected using a checksum to ensure the address is entered correctly.
 
-Because a single public key can be used to derive addresses for different Substrate chains, a single account can multiple chain-specific addresses.
+Because a single public key can be used to derive addresses for different Substrate chains, a single account can have multiple chain-specific addresses.
 For example, if you inspect the addresses for the `alice` account public key `0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d` depends on the chain-specific address type.
 
 | Chain address type | Address |
@@ -46,7 +46,7 @@ Each Substrate blockchain can register a custom prefix to create a chain-specifi
 For example, all Polkadot addresses start with `1` and all Kusama addresses start with a capital letter.
 All unregistered Substrate chains start with `5`.
 
-You can look the a chain-specific address for a public key using the `subkey inspect` commmand and `--network` option ot by using [Subscan](https://polkadot.subscan.io/tools/format_transform).
+You can look the a chain-specific address for a public key using the `subkey inspect` command and `--network` option ot by using [Subscan](https://polkadot.subscan.io/tools/format_transform).
 
 For information about generating public and private key pairs and inspecting addresses, see [subkey](/reference/command-line-tools/subkey).
 For information about chain-specific address, see the instructions in the [SS58 repository](https://github.com/paritytech/ss58-registry).


### PR DESCRIPTION
Added "by" to "This secret seed phrase can be used __ an account owner to recover access to an account if the private key is lost."

Removed the extra 'T' in the first word in "TIn addition to allowing you to derive multiple addresses from the same public key, base-58 encoding has the following benefits"

Removed an extra 'm' in command in "You can look the a chain-specific address for a public key using the subkey inspect commmand and --network option ot by using Subscan." I also think the sentence can be worded differently to convey its meaning.