### PR TITLE
Correct typo in Introduction to libraries

### DIFF
--- a/content/md/en/docs/main-docs/build/libraries.md
+++ b/content/md/en/docs/main-docs/build/libraries.md
@@ -35,7 +35,7 @@ However, the `frame_*` or `pallet_*` libraries provide the most efficient path t
 
 ## Modular architecture
 
-The separate of the core libraries provides a flexible and modular architecture for writing the blockchain logic.
+The separation of the core libraries provides a flexible and modular architecture for writing the blockchain logic.
 The primitives library provides a foundation that both the outer node and the runtime can build on without communicating directly with each other.
 Primitive types and traits are exposed in their own separate crates, so they are available to the outer node and runtime components without introducing cyclic dependency issues.
 


### PR DESCRIPTION
Change from "separate" to "separation" to correct the grammar.