### PR TITLE
Lg/install code blocks

### DIFF
--- a/content/md/en/docs/main-docs/install/linux.md
+++ b/content/md/en/docs/main-docs/install/linux.md
@@ -19,7 +19,7 @@ sudo apt install build-essential
 
 At a minimum, you need the following packages before you install Rust:
 
-```bash
+```text
 clang curl git make
 ```
 

--- a/content/md/en/docs/main-docs/install/macos.md
+++ b/content/md/en/docs/main-docs/install/macos.md
@@ -35,19 +35,19 @@ To install Homebrew:
 
 1. Download and install Homebrew by running the following command:
 
-   ```
+   ```bash
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
    ```
 
 1. Verify Homebrew has been successfully installed by running the following command:
 
-   ```
+   ```bash
    brew --version
    ```
 
    The command displays output similar to the following:
 
-   ```
+   ```bash
    Homebrew 3.3.1
    Homebrew/homebrew-core (git revision c6c488fbc0f; last commit 2021-10-30)
    Homebrew/homebrew-cask (git revision 66bab33b26; last commit 2021-10-30)
@@ -63,13 +63,13 @@ To install `openssl` and the Rust toolchain on macOS:
 
 1. Ensure you have an updated version of Homebrew by running the following command:
 
-   ```
+   ```bash
    brew update
    ```
 
 1. Install the `openssl` package by running the following command:
 
-   ```
+   ```bash
    brew install openssl
    ```
 

--- a/content/md/en/docs/main-docs/install/windows.md
+++ b/content/md/en/docs/main-docs/install/windows.md
@@ -39,7 +39,7 @@ To prepare a development environment using Windows Subsystem for Linux:
 
 1. In the PowerShell or Command Prompt terminal, run the following command:
 
-   ```
+   ```bash
    wsl --install
    ```
 
@@ -47,7 +47,7 @@ To prepare a development environment using Windows Subsystem for Linux:
 
    If you want to review the other Linux distributions available, run the following command:
 
-   ```
+   ```bash
    wsl --list --online
    ```
 
@@ -72,13 +72,13 @@ To install the Rust toolchain on WSL:
 
 1. Download the latest updates for the Ubuntu distribution using the Ubuntu Advanced Packaging Tool (`apt`) by running the following command:
 
-   ```
+   ```bash
    sudo apt update
    ```
 
 1. Add the required packages for the Ubuntu distribution by running the following command:
 
-   ```
+   ```bash
    sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
    ```
 
@@ -104,14 +104,14 @@ To install the Rust toolchain on WSL:
 
 1. Configure the Rust toolchain to use the latest stable version as the default toolchain by running the following commands:
 
-   ```
+   ```bash
    rustup default stable
    rustup update
    ```
 
 1. Add the `nightly` version of the toolchain and the `nightly` WebAssembly (`wasm`) target to your development environment by running the following commands:
 
-   ```
+   ```bash
    rustup update nightly
    rustup target add wasm32-unknown-unknown --toolchain nightly
    ```


### PR DESCRIPTION
Was missing the language identifier in some places in the macOS, windows, and linux pages.
However, we're reusing the fence block language identifier for the tabbed code blocks (Debian, Arch etc.).
I'm not sure if we can add the Copy functionality for those code blocks as a "custom" solution. Not the worst thing in the world if we can't because they are intended to be *examples* and not necessarily exactly the command that users should copy and paste (it is pretty impossible to know the specific minimum requirements for every flavor and version of Linux out in the world),