### PR TITLE
Add solution to local build errors on M1 machines

### DIFF
--- a/content/md/en/docs/main-docs/install/macos.md
+++ b/content/md/en/docs/main-docs/install/macos.md
@@ -133,6 +133,13 @@ To install `openssl` and the Rust toolchain on macOS:
    nightly-x86_64-apple-darwin (overridden by +toolchain on the command line)
    rustc 1.63.0-nightly (e71440575 2022-06-02)
    ```
+   
+   1. Install `cmake` using the following command:
+
+   ```
+   brew install cmake
+   ```
+
 
 ## Compile a Substrate node
 

--- a/content/md/en/docs/main-docs/install/troubleshooting.md
+++ b/content/md/en/docs/main-docs/install/troubleshooting.md
@@ -123,24 +123,23 @@ rustup install nightly-<yyyy-MM-dd>
 rustup target add wasm32-unknown-unknown --toolchain nightly-<yyyy-MM-dd>
 ```
 
-## Installing `cmake` or `protobuf` for M1 Mac users
+## Installing `cmake` or `protobuf` for M1 macOS users
 
-Currently, there are issues with the pre-compiled binary for the M1 macs. 
-This will result in the following error:
+Currently, there are issues compiling the Substrate node when using the packages that are pre-installed on macOS computers with the M1 chip.
 
 ```sh
 error: failed to run custom build command for prost-build v0.10.4
 ```
 
-If you run into this error, there are 2 solutions.
+If you see this error, there are two solutions.
 
-1. For the simplest solution, install `cmake` by running the following command:
+1. Install `cmake` by running the following command:
 
 ```bash
 brew install cmake
 ```
 
-1. Alternatively, install the correct pre-compiled `protoc` by running the following:
+1. Install the correct pre-compiled `protoc` by running the following set of commands:
 
 ```bash
 git clone https://github.com/protocolbuffers/protobuf.git

--- a/content/md/en/docs/main-docs/install/troubleshooting.md
+++ b/content/md/en/docs/main-docs/install/troubleshooting.md
@@ -123,7 +123,7 @@ rustup install nightly-<yyyy-MM-dd>
 rustup target add wasm32-unknown-unknown --toolchain nightly-<yyyy-MM-dd>
 ```
 
-### Installing `cmake` or `protobuf`
+## Installing `cmake` or `protobuf`
 
 Currently, there are issues with the pre-compiled binary for the M1 macs. This will result in the following error:
 ```

--- a/content/md/en/docs/main-docs/install/troubleshooting.md
+++ b/content/md/en/docs/main-docs/install/troubleshooting.md
@@ -123,22 +123,26 @@ rustup install nightly-<yyyy-MM-dd>
 rustup target add wasm32-unknown-unknown --toolchain nightly-<yyyy-MM-dd>
 ```
 
-## Installing `cmake` or `protobuf`
+## Installing `cmake` or `protobuf` for M1 Mac users
 
-Currently, there are issues with the pre-compiled binary for the M1 macs. This will result in the following error:
-```
+Currently, there are issues with the pre-compiled binary for the M1 macs. 
+This will result in the following error:
+
+```sh
 error: failed to run custom build command for prost-build v0.10.4
 ```
 
-If you see this error, there are 2 solutions.
+If you run into this error, there are 2 solutions.
 
-1. (Simplest) Just install `cmake` by running the following command:
-```
+1. For the simplest solution, install `cmake` by running the following command:
+
+```bash
 brew install cmake
 ```
-2. Alternatively, install the correct pre-compiled `protoc` by running the following:
 
-```
+1. Alternatively, install the correct pre-compiled `protoc` by running the following:
+
+```bash
 git clone https://github.com/protocolbuffers/protobuf.git
 cd protobuf
 

--- a/content/md/en/docs/main-docs/install/troubleshooting.md
+++ b/content/md/en/docs/main-docs/install/troubleshooting.md
@@ -122,3 +122,36 @@ rustup uninstall nightly
 rustup install nightly-<yyyy-MM-dd>
 rustup target add wasm32-unknown-unknown --toolchain nightly-<yyyy-MM-dd>
 ```
+
+### Installing `cmake` or `protobuf`
+
+Currently, there are issues with the pre-compiled binary for the M1 macs. This will result in the following error:
+```
+error: failed to run custom build command for prost-build v0.10.4
+```
+
+If you see this error, there are 2 solutions.
+
+1. (Simplest) Just install `cmake` by running the following command:
+```
+brew install cmake
+```
+2. Alternatively, install the correct pre-compiled `protoc` by running the following:
+
+```
+git clone https://github.com/protocolbuffers/protobuf.git
+cd protobuf
+
+brew install autoconf
+brew install automake
+brew install Libtool
+
+autoreconf -i
+./autogen.sh
+./configure
+make
+make check
+sudo make install
+
+export PATH=/opt/usr/local/bin:$PATH
+```


### PR DESCRIPTION
As explained in #1324, developers on M1 machines are experiencing the following error when building blockchain locally:

`error: failed to run custom build command for prost-build v0.10.4`

This has become a very common issue for developers, so we should add it to the docs.

See e.g.

https://substrate.stackexchange.com/questions/3565/bulding-polkadot-release-v0-9-24-fails-while-compiling-a-dependency-prost-bui


Fixes #1324