### PR TITLE
Add missing type for  pallet_contracts and fix method parameter

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
@@ -180,6 +180,7 @@ To implement the `Config` trait for the Contracts pallet in the runtime:
       type ContractAccessWeight = DefaultContractAccessWeight<BlockWeights>;
       type MaxCodeLen = ConstU32<{ 256 * 1024 }>;
       type RelaxedMaxCodeLen = ConstU32<{ 512 * 1024 }>;
+      type MaxStorageKeyLen = ConstU32<{ 512 * 1024 }>;
    }
    /*** End added block ***/
    ```

--- a/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/contracts-pallet.md
@@ -309,7 +309,7 @@ To expose the Contracts RPC API:
       
       fn get_storage(
          address: AccountId,
-         key: [u8; 32],
+         key: Vec<u8>,
          ) -> pallet_contracts_primitives::GetStorageResult {
          Contracts::get_storage(address, key)
          }


### PR DESCRIPTION
The pallet_contracts has a required associated type of [MaxStorageKeyLen](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/trait.Config.html#associatedtype.MaxStorageKeyLen)


The method [get_storage](https://paritytech.github.io/substrate/master/pallet_contracts_rpc_runtime_api/trait.ContractsApi.html#method.get_storage) provided by the trait ContractsApi, expects its `key` to be a vector. 