### PR TITLE
Fix error in add-a-pallet.md

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
@@ -72,7 +72,7 @@ To add the dependencies for the Nicks pallet to the runtime:
    For example, add a line similar to the following:
 
    ```toml
-   pallet-nicks = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v26" }
+   pallet-nicks = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
    ```
 
    This line imports the `pallet-nicks` crate as a dependency and specifies the following:


### PR DESCRIPTION
There is a mistake in the branch version for the nicks pallet dependency, it shows "polkadot-v26" instead of "polkadot-v0.9.26"