### PR TITLE
Fix typo in specify-the-origin-for-a-cal.md

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/specify-the-origin-for-a-call.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/specify-the-origin-for-a-call.md
@@ -52,7 +52,7 @@ The `ForceOrigin` type is used to specify the account that can perform certain o
 For this pallet, the `ForceOrigin` type specifies that account that can set or remove a name for another account.
 Typically, only an account with administrative privileges—such as a root superuser account—can act on behalf of another account.
 In the case of the Nicks pallet, only the owner of an account or the Root account can set or remove a reserved nickname.
-You configured this Root account in the implementation (`impl`) block when you identifies the FRAME System [`Root` origin](https://paritytech.github.io/substrate/master/frame_system/enum.RawOrigin.html#variant.Root) as the `nicks` pallet administrator.
+You configured this Root account in the implementation (`impl`) block when you identified the FRAME System [`Root` origin](https://paritytech.github.io/substrate/master/frame_system/enum.RawOrigin.html#variant.Root) as the `nicks` pallet administrator.
 For example:
 
 ```rust
@@ -196,5 +196,5 @@ There are several [tutorials](/tutorials/) that can serve as next steps for lear
 In addition to tutorials, you might want to explore the following resources to learn more.
 
 - [Privileged calls and origins](/main-docs/build/origins) provides a closer look at the default raw origin types and how to create custom origins.
-- [Events and errors](/main-docs/build/events-errors) xplains how to emit events and errors from the runtime.
+- [Events and errors](/main-docs/build/events-errors) explains how to emit events and errors from the runtime.
 - [FRAME pallets](/reference/frame-pallets/) offers an overview of the most commonly-used predefined FRAME pallets.


### PR DESCRIPTION
Change from "identifies" to "identified" and "xplains" to "explain"