### PR TITLE
Fix why-substrate typos

### DIFF
--- a/content/md/en/docs/fundamentals/why-substrate.md
+++ b/content/md/en/docs/fundamentals/why-substrate.md
@@ -25,14 +25,13 @@ However, Substrate might be the perfect choice if you want to build a blockchain
 - customizable with predefined composable modular components
 - able to evolve and change with upgrades over time
 
-Substrate is a Software Development Kit (SDK) specifically designed to provide you with all of the fundamental components s blockchain requires so you can focus on crafting the logic that makes your chain unique and innovative.
+Substrate is a Software Development Kit (SDK) specifically designed to provide you with all of the fundamental components a blockchain requires so you can focus on crafting the logic that makes your chain unique and innovative.
 Unlike other distributed ledger platforms, Substrate is:
 
 - [Flexible](#flexible)
 - [Open](#open)
 - [Interoperable](#interoperable)
 - [Future-proof](#future-proof)
-- [Where to go next](#where-to-go-next)
 
 ## Flexible
 


### PR DESCRIPTION
A minor typo and what appears to be one linked section too many I found while reading through the documentation.