### PR TITLE
Fix broken URL for base-58 encoding

### DIFF
--- a/content/md/en/docs/fundamentals/accounts-addresses-keys.md
+++ b/content/md/en/docs/fundamentals/accounts-addresses-keys.md
@@ -25,7 +25,7 @@ Instead of using the public key directly, Substrate allows you generate multiple
 
 Substrate enables you to use a single public key to derive multiple addresses so you can interact with multiple chains without creating separate public and private key pairs for each network.
 By default, the addresses associated with the public key for an account use the Substrate [**SS58 address format**](/reference/glossary/#ss58-address-format).
-This address format is based on [base-58 encoding](https://tools.ietf.org/id/draft-msporny-base58-01.html).
+This address format is based on [base-58 encoding](https://datatracker.ietf.org/doc/html/draft-msporny-base58-01).
 In addition to allowing you to derive multiple addresses from the same public key, base-58 encoding has the following benefits:
 
 - Encoded addresses consist of 58 alphanumeric characters.


### PR DESCRIPTION
change `https://datatracker.ietf.org/doc/id/draft-msporny-base58-01.html` to `https://datatracker.ietf.org/doc/html/draft-msporny-base58-01`