### PR TITLE
Fix wrong ink! code

### DIFF
--- a/content/md/en/docs/tutorials/smart-contracts/build-a-token-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/build-a-token-contract.md
@@ -375,8 +375,8 @@ To emit the Transfer event:
    let to_balance = self.balance_of_impl(to);
    self.balances.insert(to, &(to_balance + value));
    self.env().emit_event(Transfer {
-       from: Some(*from),
-       to: Some(*to),
+       from: Some(from),
+       to: Some(to),
        value,
    });
    ```


### PR DESCRIPTION
fn `transfer_from_to` 's `from` and `to` parameters are not borrowed types