### PR TITLE
add --release option to cargo check

### DIFF
--- a/content/md/en/docs/tutorials/get-started/authorize-specific-nodes.md
+++ b/content/md/en/docs/tutorials/get-started/authorize-specific-nodes.md
@@ -162,7 +162,7 @@ To add the `node-authorization` pallet to the Substrate runtime:
 1. Check that the new dependencies resolve correctly by running the following command:
 
    ```bash
-   cargo check -p node-template-runtime
+   cargo check -p node-template-runtime --release
    ```
 
 ### Add an administrative rule
@@ -238,7 +238,7 @@ To implement the `node-authorization` pallet in your runtime:
 1. Check that the configuration can compile by running the following command:
 
    ```bash
-   cargo check -p node-template-runtime
+   cargo check -p node-template-runtime --release
    ```
 
 ### Add genesis storage for authorized nodes


### PR DESCRIPTION
Minor optimisation suggestion, feel free to ignore if not appropriate.

Adds the `--release` flag to `cargo check` commands to re-use the built artifacts from `cargo build --release` in the previous section(s). It just prevents a full debug build of the project on the first cargo check.