### PR TITLE
auto-select local node in portal

### DIFF
--- a/content/md/en/docs/tutorials/get-started/authorize-specific-nodes.md
+++ b/content/md/en/docs/tutorials/get-started/authorize-specific-nodes.md
@@ -485,7 +485,7 @@ This tutorial uses the Sudo pallet for governance.
 Therefore, you can use the Sudo pallet to call the `addWellKnownNode` function provided by `node-authorization` pallet to add the third node.
 To keep things simple, you can use the Polkadot/Substrate Portal application to access the Sudo pallet.
 
-1. Open the [Polkadot/Substrate Portal](https://polkadot.js.org/apps/#/explorer) in a browser.
+1. Open the [Polkadot/Substrate Portal](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer) in a browser.
 
 1. Click **Developer** and select **Sudo**.
 


### PR DESCRIPTION
The Polkadot/Substrate Portal defaults to Polkadot the first time the portal is used. An instruction step is missing in the `Authorize access for the third node` section to switch to the local node as per the screenshot included in the documentation beneath it. This proposed change would auto select the local node, but it may be better to add a step on how to manually switch.

PS - the url was simply copied from the result of doing the switch manually.