### PR TITLE
add local firewall note

### DIFF
--- a/content/md/en/docs/tutorials/get-started/authorize-specific-nodes.md
+++ b/content/md/en/docs/tutorials/get-started/authorize-specific-nodes.md
@@ -508,7 +508,7 @@ To keep things simple, you can use the Polkadot/Substrate Portal application to 
    ![Verify the Sudo event](/media/images/docs/tutorials/permissioned-network/sudo-events-add-node.png)
 
    After the transaction is included in the block, you should see the `charlie` node is connected to the `alice` and `bob` nodes, and starts to sync blocks.
-   The three nodes can find each other using the [mDNS](https://paritytech.github.io/substrate/master/sc_network/index.html) discovery mechanism that is enabled by default in a local network.
+   The three nodes can find each other using the [mDNS](https://paritytech.github.io/substrate/master/sc_network/index.html) discovery mechanism that is enabled by default in a local network. Also ensure any local firewall is configured to allow mDNS.
    
    If your nodes are not on the same local network, you should use the command-line option `--no-mdns` to disable it.
 


### PR DESCRIPTION
Following the guide, my third node on localhost was unable to automatically connect to the local testnet due to local firewall blocking all incoming connections (https://substrate.stackexchange.com/a/1657). A suggestion is to add a small hint/reminder here which may be helpful.