### PR TITLE
Flipper contract Update and test

### DIFF
--- a/content/md/en/docs/tutorials/smart-contracts/prepare-your-first-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/prepare-your-first-contract.md
@@ -41,15 +41,13 @@ To update your development environment:
 
 1. Open a terminal shell on your computer.
 
-1. Change to the root directory where you compiled the Substrate node template.
-
-1. Update your Rust environment by running the following command:
+2. Update your Rust environment by running the following command:
 
    ```bash
    rustup component add rust-src --toolchain nightly
    ```
 
-1. Verify that you have the WebAssembly target installed by running the following command:
+3. Verify that you have the WebAssembly target installed by running the following command:
 
    ```bash
    rustup target add wasm32-unknown-unknown --toolchain nightly
@@ -57,7 +55,7 @@ To update your development environment:
 
    If the target is installed and up-to-date, the command displays output similar to the following:
 
-   ```bash
+   ```text
    info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
    ```
 
@@ -65,7 +63,6 @@ To update your development environment:
 
 To simplify this tutorial, you can [download](https://github.com/paritytech/substrate-contracts-node/releases) a precompiled Substrate node for Linux or macOS.
 The precompiled binary includes the FRAME pallet for smart contracts by default.
-Alternatively, you can build the preconfigured `contracts-node` manually by running `cargo install contracts-node` on your local computer.
 
 To install the contracts node on macOS or Linux:
 
@@ -75,6 +72,7 @@ To install the contracts node on macOS or Linux:
 
 1. Open the downloaded file and extract the contents to a working directory.
 
+Alternatively, you can build the preconfigured `contracts-node` manually by running `cargo install contracts-node` on your local computer.
 If you can't download the precompiled node, you can compile it locally with a command similar to the following:
 
 ```bash
@@ -85,7 +83,7 @@ You can find the latest tag to use on the [Tags](https://github.com/paritytech/s
 
 ## Install additional packages
 
-After compiling the `contracts-node` package, you need to install two additional packages:
+After downloading or compiling the `contracts-node` package, you need to install two additional packages:
 
 - The WebAssembly **binaryen** package for your operating system to optimize the WebAssembly bytecode for the contract.
 - The `cargo-contract` command line interface you'll use to set up smart contract projects.
@@ -119,19 +117,19 @@ The `cargo-contract` package provides a command-line interface for working with 
 
 1. Open a terminal shell on your computer.
 
-1. Install `dylint-link`, required to lint ink! contracts, warning you about things like using API's in a way that could lead to security issues.
+2. Install `cargo-dylint` to check ink! contracts and warn you about issues that might lead to security vulnerabilities.
 
    ```bash
-   cargo install dylint-link
+   cargo install cargo-dylint
    ```
 
-1. Install `cargo-contract` by running the following command:
+3. Install `cargo-contract` by running the following command:
 
    ```bash
    cargo install cargo-contract --force
    ```
 
-1. Verify the installation and explore the commands available by running the following command:
+4. Verify the installation and explore the commands available by running the following command:
 
    ```bash
    cargo contract --help
@@ -165,7 +163,7 @@ To generate the files for a smart contract project:
 
    You should see that the directory contains the following files:
 
-   ```bash
+   ```text
    -rwxr-xr-x   1 dev-doc  staff   285 Mar  4 14:49 .gitignore
    -rwxr-xr-x   1 dev-doc  staff  1023 Mar  4 14:49 Cargo.toml
    -rwxr-xr-x   1 dev-doc  staff  2262 Mar  4 14:49 lib.rs
@@ -199,7 +197,12 @@ To explore the default project files:
 
 1. Save any changes to the `Cargo.toml` file, then close the file.
 
-1. Open the `lib.rs` file in a text editor and review the functions defined for the contract.
+1. Open the `lib.rs` file in a text editor and review the macros, constructors, and functions defined for the contract.
+   
+   - The storage macro defines a structure to stores a single boolean value for the contract.
+   - The `new` and `default` functions initialize the boolean value to false.
+   - There's a `message` macro with a `flip` function to change the state of the data stored for the contract.
+   - There's a `message` macro with a `get` function to get the current state of the data stored for the contract.
 
 ### Test the default contract
 
@@ -212,15 +215,15 @@ To test the contract:
 
 1. Verify that you are in the `flipper` project folder, if needed.
 
-1. Use the `test` subcommand and `nightly` toolchain to execute the default tests for the `flipper` contract by running the following command:
+2. Use the `test` subcommand to execute the default tests for the `flipper` contract by running the following command:
 
    ```bash
-   cargo +nightly test
+   cargo test
    ```
 
-   The command should display output similar to the following to indicate successful test completion:
+   The command should compile the program and display output similar to the following to indicate successful test completion:
 
-   ```bash
+   ```text
    running 2 tests
    test flipper::tests::it_works ... ok
    test flipper::tests::default_works ... ok
@@ -238,7 +241,7 @@ To build the WebAssembly for this smart contract:
 
 1. Verify that you are in the `flipper` project folder.
 
-1. Compile the `flipper` smart contract by running the following command:
+1. Compile the `flipper` smart contract using the `nightly` toolchain by running the following command:
 
    ```bash
    cargo +nightly contract build
@@ -248,8 +251,8 @@ To build the WebAssembly for this smart contract:
    For example, you should see output similar to the following:
 
    ```text
-   Original wasm size: 47.9K, Optimized: 22.8K
-
+   Original wasm size: 47.8K, Optimized: 22.4K
+   
    The contract was built in DEBUG mode.
 
    Your contract artifacts are ready. You can find them in:
@@ -258,8 +261,9 @@ To build the WebAssembly for this smart contract:
    - flipper.contract (code + metadata)
    - flipper.wasm (the contract's code)
    - metadata.json (the contract's metadata)
-   The `.contract` file can be used for deploying your contract to your chain.
    ```
+
+   The `.contract` file that includes both the business logic and metadata is the file you use to deploy the contract on a chain.
 
    The `metadata.json` file in the `target/ink` directory describes all the interfaces that you can use to interact with this contract. This file contains several important sections:
 
@@ -275,9 +279,17 @@ If you have successfully installed [`substrate-contracts-node`](https://github.c
 
 To start the preconfigured `contracts-node`:
 
-1. Open a terminal shell on your computer, if needed.
+1. Open a new terminal shell on your computer, if needed.
 
-1. Start the contracts node in local development mode by running the following command:
+1. Change to the root directory that contains the `substrate-contracts-node` binary.
+
+   For example, if you downloaded the precompiled binary on a macOS computer, you can run the following command:
+
+   ```bash
+   cd artifacts/substrate-contracts-node-mac
+   ```
+
+2. Start the contracts node in local development mode by running the following command:
 
    ```bash
    substrate-contracts-node --dev
@@ -305,9 +317,9 @@ To start the preconfigured `contracts-node`:
    To interact with the blockchain, you need to connect to this node.
    You can connect to the node through a browser by opening the [Contracts UI](https://contracts-ui.substrate.io).
 
-1. Navigate to the [Contracts UI](https://contracts-ui.substrate.io) in a web browser, then click **Yes allow this application access**.
+3. Navigate to the [Contracts UI](https://contracts-ui.substrate.io) in a web browser, then click **Yes allow this application access**.
 
-1. Select **Local Node**.
+4. Select **Local Node**.
 
    ![Connect to the local node](/media/images/docs/tutorials/ink-workshop/connect-to-local-node.png)
 
@@ -342,7 +354,7 @@ For this tutorial, you use the Contracts UI front-end to deploy the `flipper` co
 
 To upload the smart contract source code:
 
-1. Open to the [Contracts UI](https://contracts-ui.substrate.io) in a web browser.
+1. Open to the [Contracts UI](https://contracts-ui.substrate.io/?rpc=ws://127.0.0.1:9944) in a web browser.
 
 1. Verify that you are connected to the **Local Node**.
 
@@ -373,18 +385,18 @@ To create the instance:
 
 1. Review and accept the default **Deployment Constructor** options for the initial version of the smart contract.
 
-1. Review and accept the default **Max Gas Allowed** of `200000`.
+2. Review and accept the default **Max Gas Allowed**.
 
    ![Create an instance of the smart contract](/media/images/docs/tutorials/ink-workshop/create-instance.png)
 
-1. Click **Next**.
+3. Click **Next**.
 
    The transaction is now queued.
    If you needed to make changes, you could click **Go Back** to modify the input.
 
    ![Complete instantiation](/media/images/docs/tutorials/ink-workshop/complete-upload.png)
 
-1. Click **Upload and Instantiate**.
+4. Click **Upload and Instantiate**.
 
    Depending on the account you used, you might be prompted for the account password.
    If you used a predefined account, you won't need to provide a password.
@@ -412,8 +424,8 @@ To test the `get()` function:
 1. Click **Read**.
 
 1. Verify that the value `false` is returned in the Call Results.
-
-![Calling the get() function returns false](/media/images/docs/tutorials/ink-workshop/call-results-get.png)
+   
+   ![Calling the get() function returns false](/media/images/docs/tutorials/ink-workshop/call-results-get.png)
 
 ### flip() function
 


### PR DESCRIPTION
cargo-contract 1.5.0 does seem to require specific nightly versions. Everything works if you use this set of commands with nightly-2022-08-15:
```
rustup toolchain install nightly-2022-08-15
rustup target add wasm32-unknown-unknown --toolchain nightly-2022-08-15
rustup component add rust-src --toolchain nightly-2022-08-15
cargo +nightly-2022-08-15 contract build
```

Released SE answer: https://substrate.stackexchange.com/questions/4785/errore0158-when-testing-default-contract-from-flipper