### PR TITLE
clarify session keys requirement

### DIFF
--- a/content/md/en/docs/tutorials/connect-relay-and-parachains/acquire-a-testnet-slot.md
+++ b/content/md/en/docs/tutorials/connect-relay-and-parachains/acquire-a-testnet-slot.md
@@ -120,7 +120,7 @@ To modify the chain specification:
    ...
    ```
 
-1. Add the public key for your account to the session keys section.
+1. Add the public key for your account to the session keys section. Each configured session key will require a running collator.
 
    ```json
    ...


### PR DESCRIPTION
I had problems producing parachain blocks due to simply *adding* my public key to the existing default session keys in generated file, rather than *replacing* the session keys. The instruction says "Add" but the code snippet only shows a single key, which I missed unfortunately. Based on https://substrate.stackexchange.com/a/179/3138 (3.), it seems a running collator is required for each configured key before blocks will be produced, so an additional note may be especially useful, as going through the whole process of requesting a slot, syncing the relay chain, only to find you've made a small mistake is rather time consuming.

PS - I may have gotten something else wrong, but I am now producing blocks by simply launching the additional missing collators for the other default session keys.