### PR TITLE
Update add-a-pallet.md

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
@@ -203,7 +203,7 @@ To implement the `nicks` pallet in your runtime:
     type MaxLength = ConstU32<32>;
 
     // The ubiquitous event type.
-    type RuntimeEvent = RuntimeEvent;
+    type Event = Event;
    }
 
 1. Add Nicks to the `construct_runtime!` macro.


### PR DESCRIPTION
Nicks pallet uses Event instead of RuntimeEvent in polkadot-v0.9.28.
won't compile if it's RuntimeEvent as it is not defined.
check https://github.com/paritytech/substrate/blob/polkadot-v0.9.28/frame/nicks/src/lib.rs