### PR TITLE
Comment section out

### DIFF
--- a/content/md/en/docs/build/custom-pallets.md
+++ b/content/md/en/docs/build/custom-pallets.md
@@ -38,7 +38,7 @@ However, some macros enforce particular requirements on function declarations.
 For example, the `Config` trait must be bound by `frame_system::Config` and the `#[pallet::pallet]` struct must be declared as `pub struct Pallet<T>(_);`.
 For an overview of the macros used in FRAME pallets, see [FRAME macros](/reference/frame-macros/).
 
-## Useful FRAME traits
+<!-- ## Useful FRAME traits
 
 - Pallet Origin
 - Origins: EnsureOrigin, EnsureOneOf
@@ -55,4 +55,4 @@ Your pallet's `Config` trait is what get's implemented for `Runtime` which is a 
 - Side chain architecture references
 - Api endpoints: on_initialize, off_chain workers ?
 
-Write content that links to basic and intermediate how-to guides.
+Write content that links to basic and intermediate how-to guides. -->


### PR DESCRIPTION
Caught some text that was probably meant to be notes. Looking at this article, we could probably list some useful traits from https://paritytech.github.io/substrate/master/frame_support/traits/index.html#traits

Happy to add some commits to improve this article, though I could use a little direction. Is the purpose of this article to be a sort of landing page that branches out to docs like macros, pallet coupling, different existing pallets or is it meant to provide examples of composing a runtime with combining existing pallets + some custom pallet?

We can also merge this for now and improve in a follow-up PR, let me know.