### PR TITLE
Fix broken link to "Get oriented" section in "Prepare a working environment" section

### DIFF
--- a/content/md/en/docs/tutorials/collectibles-workshop/01-prepare.md
+++ b/content/md/en/docs/tutorials/collectibles-workshop/01-prepare.md
@@ -10,7 +10,7 @@ If you discover something's missing, click the corresponding link.
 
 You can complete this workshop without setting up a local working environment if you use the [Substrate Playground](https://substrate.io/developers/playground/).
 However, if you use the Substrate Playground, the changes you make aren't saved when you end a session.
-If you use Substrate Playground, you can skip this checklist and go directly to [Get oriented](/02-orientation/), but be sure to save copies of the files you edit!
+If you use Substrate Playground, you can skip this checklist and go directly to [Get oriented](/tutorials/collectibles-workshop/02-orientation/), but be sure to save copies of the files you edit!
 
 The instructions in the workshop assume you are working in a local environment. 
 


### PR DESCRIPTION
closes #1692 