### PR TITLE
Update add-trusted-nodes.md

### DIFF
--- a/content/md/en/docs/tutorials/get-started/add-trusted-nodes.md
+++ b/content/md/en/docs/tutorials/get-started/add-trusted-nodes.md
@@ -206,7 +206,8 @@ To create a new chain specification based on the local specification:
 
    ```json
    "aura": { "authorities": [
-     "5CfBuoHDvZ4fd8jkLQicNL8tgjnK8pVG9AiuJrsNrRAx6CNW", "5CXGP4oPXC1Je3zf5wEDkYeAqGcGXyKWSRX2Jm14GdME5Xc5"
+       "5CfBuoHDvZ4fd8jkLQicNL8tgjnK8pVG9AiuJrsNrRAx6CNW", 
+       "5CXGP4oPXC1Je3zf5wEDkYeAqGcGXyKWSRX2Jm14GdME5Xc5"
      ]
    },
    ```


### PR DESCRIPTION
ISSUE:
One with a smaller screen (laptop or tablet) can't see entire JSON blob with Aura keys field and it may lead to the wrong assumption there is only one key, but in reality there are two.  

FIX:
Added line break for "aura" field JSON for better readability on smaller screens (e.g. laptops), so it's clearly visible there are two keys.

