### PR TITLE
Correct code example to include `Balance` type `u128`

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/add-a-pallet.md
@@ -143,6 +143,10 @@ To review the `Config` trait for the Balances pallet:
 1. Locate the `Balances` pallet and note that it consists of the following implementation (`impl`)code block:
 
    ```rust
+   pub type Balance = u128;
+
+   // ...
+
    /// Existential deposit.
    pub const EXISTENTIAL_DEPOSIT: u128 = 500;
    


### PR DESCRIPTION
The text references the type of `Balances` to be `u128` which is not clear from the above code example: 
> For example, this `impl` block configures the Balances pallet to use the `u128` type to track balances.

The missing `Balances` type is defined here: [https://github.com/substrate-developer-hub/substrate-node-template/blob/904f7679273c40ebead46de4f047a7eaf24e1017/runtime/src/lib.rs#L64](https://github.com/substrate-developer-hub/substrate-node-template/blob/904f7679273c40ebead46de4f047a7eaf24e1017/runtime/src/lib.rs#L64)