### PR TITLE
Fixing Issues Discovered at PBA2

### DIFF
--- a/content/md/en/docs/tutorials/connect-relay-and-parachains/connect-a-local-parachain.md
+++ b/content/md/en/docs/tutorials/connect-relay-and-parachains/connect-a-local-parachain.md
@@ -44,10 +44,10 @@ To build the parachain template:
 
 2. Clone the branch of the `substrate-parachain-template` repository that matches the release branch you used to configure the relay chain.
    
-   For example, if you used the `release-v0.9.28` Polkadot release branch to configure the local relay chain, use the `polkadot-v0.9.28` branch for the parachain template.
+   For example, if you used the `release-v0.9.37` Polkadot release branch to configure the local relay chain, use the `polkadot-v0.9.37` branch for the parachain template.
    
    ```bash
-   git clone --depth 1 --branch polkadot-v0.9.28 https://github.com/substrate-developer-hub/substrate-parachain-template.git
+   git clone --depth 1 --branch polkadot-v0.9.37 https://github.com/substrate-developer-hub/substrate-parachain-template.git
    ```
 
 1. Change to the root of the parachain template directory by running the following command:
@@ -60,7 +60,7 @@ To build the parachain template:
    If you want to save your changes and make this branch easy to identify you can create a new branch by running a command similar to the following:
 
    ```bash
-   git switch -c my-branch-v0.9.28
+   git switch -c my-branch-v0.9.37
    ```
 
 3. Build the parachain template collator by running the following command:
@@ -170,9 +170,15 @@ To register your parachain with the local relay chain, you must modify the defau
    ...
    ```
 
-4. Save your changes and close the plain text chain specification file.
+4. If you are completing this tutorial at the same time as anyone on the same local network, then an additional step is needed to prevent accidentally peering with their nodes. Find the following line and add characters to make your protocolId unique:
+
+```json
+   "protocolId": "template-local"
+```
+
+5. Save your changes and close the plain text chain specification file.
    
-5. Generate a raw chain specification file from the modified chain specification file by running the following command:
+6. Generate a raw chain specification file from the modified chain specification file by running the following command:
    
    ```bash
    ./target/release/parachain-template-node build-spec --chain plain-parachain-chainspec.json --disable-default-bootnode --raw > raw-parachain-chainspec.json

--- a/content/md/en/docs/tutorials/connect-relay-and-parachains/prepare-a-local-relay-chain.md
+++ b/content/md/en/docs/tutorials/connect-relay-and-parachains/prepare-a-local-relay-chain.md
@@ -21,13 +21,15 @@ The local relay chain is required to set up a local testing environment that a t
 
 ## Before you begin
 
+Before you begin, consider the following:
+
+- Though it is not a strict prerequisite, it is recommended that you first learn how to generate chain specifications for a private network of trusted validators as described in [Add trusted nodes](/tutorials/get-started/add-trusted-nodes/). 
+
 Before you begin, verify the following:
 
 - You have configured your environment for Substrate development by installing [Rust and the Rust toolchain](/install/).
 
 - You have completed [Build a local blockchain](/tutorials/get-started/build-local-blockchain/) and know how to compile and run a Substrate node.
-
-- You know how to generate chain specifications for a private network of trusted validators as described in [Add trusted nodes](/tutorials/get-started/add-trusted-nodes/).
 
 - You are generally familiar with Polkadot [architecture and terminology](https://wiki.polkadot.network/docs/learn-architecture).
 
@@ -55,12 +57,12 @@ Therefore, this tutorial uses code from the Polkadot repository to prepare the l
 1. Clone the most recent release branch of the Polkadot repository to prepare a stable working environment.
    
    Release branches tend to be the most reliable and use the naming convention `release-v<n..n.n>`.
-   For example, the release branch used in this tutorial is `release-v0.9.32`.
-   Newer releases are likely to be available and, in most cases, you can substitute a more recent release branch instead of using the `release-v0.9.32` branch a long as you use the same branch for every module.
+   For example, the release branch used in this tutorial is `release-v0.9.37`.
+   Newer releases are likely to be available and, in most cases, you can substitute a more recent release branch instead of using the `release-v0.9.37` branch a long as you use the same branch for every module.
    You can find information about each release on the [Releases](https://github.com/paritytech/polkadot/releases) tab in GitHub.
    
    ```bash
-   git clone --branch release-v0.9.32 https://github.com/paritytech/polkadot.git
+   git clone --branch release-v0.9.37 https://github.com/paritytech/polkadot.git
    ```
 
 2. Change to the root of the `polkadot` directory by running the following command:
@@ -101,6 +103,12 @@ If you wanted to connect two parachains with a single collator each, you would n
 In general, you would need to modify the chain specification and hard-code additional validators to set up a local test network for two or more parachains.
 
 ### Plain and raw chain specification files
+
+If you are completing this tutorial at the same time as anyone on the same local network, then you must download and modify the Plain sample relay chain spec to prevent accidentally peering with their nodes. Find the following line in the plain chain spec and add characters to make your protocolId unique:
+
+```json
+   "protocolId": "dot"
+```
 
 There are two formats for the sample chain specification—a JSON file in plain text format and a JSON file in SCALE-encoded raw format. 
 

--- a/content/md/en/docs/tutorials/connect-relay-and-parachains/prepare-a-local-relay-chain.md
+++ b/content/md/en/docs/tutorials/connect-relay-and-parachains/prepare-a-local-relay-chain.md
@@ -104,12 +104,6 @@ In general, you would need to modify the chain specification and hard-code addit
 
 ### Plain and raw chain specification files
 
-If you are completing this tutorial at the same time as anyone on the same local network, then you must download and modify the Plain sample relay chain spec to prevent accidentally peering with their nodes. Find the following line in the plain chain spec and add characters to make your protocolId unique:
-
-```json
-   "protocolId": "dot"
-```
-
 There are two formats for the sample chain specification—a JSON file in plain text format and a JSON file in SCALE-encoded raw format. 
 
 - [Plain sample relay chain spec](/assets/tutorials/relay-chain-specs/plain-local-chainspec.json)
@@ -121,6 +115,12 @@ For information about converting a chain specification to use the raw format, se
 
 The sample chain specification is only valid for a single parachain with two validator nodes.
 If you add other validators, add additional parachains to your relay chain, or want to use custom account keys instead of the predefined account, you'll need to create a custom chain specification file.
+
+If you are completing this tutorial at the same time as anyone on the same local network, then you must download and modify the Plain sample relay chain spec to prevent accidentally peering with their nodes. Find the following line in the plain chain spec and add characters to make your protocolId unique:
+
+```json
+   "protocolId": "dot"
+```
 
 ## Start the relay chain node
 


### PR DESCRIPTION
At PBA2 we attempted to run the first two tutorials in the section "Connect Relay and Parachains" as an exercise. This revealed issues with outdated version numbering, non-unique protocol ids, and confusion about prerequisites. Thus, this bundle of fixes.