### PR TITLE
Fix the URL for the Ruby SCALE codec implementation

### DIFF
--- a/content/md/en/docs/reference/scale-codec.md
+++ b/content/md/en/docs/reference/scale-codec.md
@@ -78,4 +78,4 @@ SCALE Codec has been implemented in other languages, including:
 - AssemblyScript: [`LimeChain/as-scale-codec`](https://github.com/LimeChain/as-scale-codec)
 - Haskell: [`airalab/hs-web3`](https://github.com/airalab/hs-web3/tree/master/packages/scale)
 - Java: [`emeraldpay/polkaj`](https://github.com/emeraldpay/polkaj)
-- Ruby: [`itering/scale.rb`](https://github.com/itering/scale.rb)
+- Ruby: [`wuminzhe/scale_rb`](https://github.com/wuminzhe/scale_rb)


### PR DESCRIPTION
The Ruby library that is linked to in the docs has been deprecated and archived in favor of a newer implementation.

This change just changes the reference to point to the currently supported version for Ruby.