### PR TITLE
Add some links to some SS58 implementations.

### DIFF
--- a/content/md/en/docs/reference/address-formats.md
+++ b/content/md/en/docs/reference/address-formats.md
@@ -204,3 +204,12 @@ console.log(isValid)
 ```
 
 If the function returns `true`, the address you specified is a valid address.
+
+### Other SS58 implementations
+
+Support for encoding and decoding Substrate SS58 addresses has been implemented in several other languages and libraries.
+
+- Crystal: [`wyhaines/base58.cr`](https://github.com/wyhaines/base58.cr)
+- Go: [`itering/subscan`](https://github.com/subscan-explorer/subscan-essentials/blob/master/util/ss58/ss58.go)
+- Python: [`polkascan/py-scale-codec`](https://github.com/polkascan/py-scale-codec/blob/master/scalecodec/utils/ss58.py)
+- Typescript: [`subsquid/squid-sdk`](https://github.com/subsquid/squid-sdk/tree/master/substrate/ss58-codec)


### PR DESCRIPTION
We have a very complete reference of implementations for Base58 on our page about Base58, which is very useful for anyone coming at the Substrate ecosystem from another language, or for anyone who wants to see how things work at a low level, but we are lacking the same set of resources for our SS58 checksumming / address format implementation.

This list is probably incomplete, but it has the 4 most-complete implementations that I have found so far outside of the Substrate and Polkadot-js core implementations, and I think it could be useful, just like the Base58 list, for anyone looking at our ecosystem from outside of it, particularly if they are not Rust programmers, as our docs and our code for our Rust SS58 implementation are pretty dense.