### PR TITLE
Fix broken link to the RPC call page

### DIFF
--- a/content/md/en/docs/build/index.md
+++ b/content/md/en/docs/build/index.md
@@ -16,6 +16,6 @@ The topics in this section provide a more detailed exploration of the code used 
 - [Randomness](/build/randomness) suggests ways you can include randomness in applications that run on a Substrate-based blockchain.
 - [Chain specification](/build/chain-spec) discusses the use of chain specifications, including what you can and can't modify, and how to distribute customized chain specifications.
 - [Privileged calls and origins](/build/origins) describes how you can use predefined or custom origins to identify the originator of a function call.
-- [Remote procedure calls](/build/custom-rpc) summarizes how you can use remote procedure calls and RPC methods to interact with a Substrate node.
+- [Remote procedure calls](/build/remote-procedure-calls/) summarizes how you can use remote procedure calls and RPC methods to interact with a Substrate node.
 - [Application development](/build/application-development/) introduces the role of metadata and front-end libraries as tools for building applications that run on the blockchain.
 - [Upgrade the runtime](/build/upgrade-the-runtime/) explains how runtime versioning and storage migration support runtime upgrades, enabling your blockchain to evolve over time.


### PR DESCRIPTION
The URL for the page detailing RPC calls changed, but the link off of the build/index.md wasn't updated. This fixes that.