### PR TITLE
This how-to was removed, but this link to it was missed.

### DIFF
--- a/content/md/en/docs/build/runtime-storage.md
+++ b/content/md/en/docs/build/runtime-storage.md
@@ -338,7 +338,6 @@ This type of hasher should only be used when the starting key is already a crypt
 
 Check out some guides covering various topics on storage:
 
-- [Mint basic tokens](/reference/how-to-guides/basics/mint-basic-tokens) using a storage map.
 - [How-to: Create a storage structure](/reference/how-to-guides/pallet-design/create-a-storage-structure)
 - [StorageValue](https://paritytech.github.io/substrate/master/frame_support/storage/types/struct.StorageValue.html)
 - [StorageMap](https://paritytech.github.io/substrate/master/frame_support/storage/types/struct.StorageMap.html)


### PR DESCRIPTION
The how-to for minting basic tokens was removed, but this link to it was missed.