### PR TITLE
Replace `cargo contract test` with `cargo test`

### DIFF
--- a/content/md/en/docs/tutorials/smart-contracts/build-a-token-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/build-a-token-contract.md
@@ -140,7 +140,7 @@ To build an ERC-20 token smart contract:
 1. Verify that the program compiles and passes the trivial test by running the following command
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:
@@ -314,7 +314,7 @@ To add the transfer functions to the smart contract:
 1. Verify that the program compiles and passes the test cases by running the following command:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:
@@ -439,7 +439,7 @@ To emit the Transfer event:
 1. Verify that the program compiles and passes all tests by running the following command:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:
@@ -544,14 +544,14 @@ To add the approval logic to the smart contract:
    ```
 
 1. Instantiate and add the `allowances` `Mapping` in the new() constructor.
-   
+
    ```rust
    #[ink(constructor)]
    pub fn new(total_supply: Balance) -> Self {
        // -- snip --
-       
+
        let allowances = Mapping::default();
-   
+
        Self {
            total_supply,
            balances,
@@ -677,7 +677,7 @@ To add the `transfer_from` logic to the smart contract:
 1. Verify that the program compiles and passes all tests by running the following command:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:

--- a/content/md/en/docs/tutorials/smart-contracts/develop-a-smart-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/develop-a-smart-contract.md
@@ -93,7 +93,7 @@ To create a new project for your smart contract:
 1. Verify that the program compiles and passes the trivial test by running the following command:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    You can ignore any warnings because this template code is simply a skeleton.
@@ -251,7 +251,7 @@ To update the smart contract:
 1. Check your work using the `test` subcommand:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:
@@ -306,7 +306,7 @@ To add the public function to the smart contract:
 1. Check your work using the `test` subcommand:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
 ## Add a function to modify the storage value
@@ -346,7 +346,7 @@ To add a function for incrementing the stored value:
 1. Check your work using the `test` subcommand:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:

--- a/content/md/en/docs/tutorials/smart-contracts/prepare-your-first-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/prepare-your-first-contract.md
@@ -196,7 +196,7 @@ To test the contract:
 1. Use the `test` subcommand to execute the default tests for the `flipper` contract by running the following command:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should compile the program and display output similar to the following to indicate successful test

--- a/content/md/en/docs/tutorials/smart-contracts/use-maps-for-storing-values.md
+++ b/content/md/en/docs/tutorials/smart-contracts/use-maps-for-storing-values.md
@@ -192,7 +192,7 @@ To add a storage map to the `incrementer` contract:
 1. Use the `test` subcommand and `nightly` toolchain to test your work by running the following command:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:
@@ -286,7 +286,7 @@ To add insert and remove functions to the contract:
 1. Check your work using the `test` subcommand:
 
    ```bash
-   cargo contract test
+   cargo test
    ```
 
    The command should display output similar to the following to indicate successful test completion:


### PR DESCRIPTION
`cargo contract test` was replaces with `cargo test` in https://github.com/paritytech/cargo-contract/pull/958