### PR TITLE
Fix deprecation warning in tutorial

### DIFF
--- a/content/md/en/docs/tutorials/work-with-pallets/use-macros-in-a-custom-pallet.md
+++ b/content/md/en/docs/tutorials/work-with-pallets/use-macros-in-a-custom-pallet.md
@@ -269,6 +269,7 @@ To implement this logic in the proof-of-existence pallet:
     #[pallet::call]
     impl<T: Config> Pallet<T> {
       #[pallet::weight(0)]
+      #[pallet::call_index(1)]
       pub fn create_claim(origin: OriginFor<T>, claim: T::Hash) -> DispatchResult {
         // Check that the extrinsic was signed and get the signer.
         // This function will return an error if the extrinsic is not signed.
@@ -290,6 +291,7 @@ To implement this logic in the proof-of-existence pallet:
       }
 
       #[pallet::weight(0)]
+      #[pallet::call_index(2)]
       pub fn revoke_claim(origin: OriginFor<T>, claim: T::Hash) -> DispatchResult {
         // Check that the extrinsic was signed and get the signer.
         // This function will return an error if the extrinsic is not signed.


### PR DESCRIPTION
Currently, the [Use macros in a custom pallet](https://docs.substrate.io/tutorials/work-with-pallets/use-macros-in-a-custom-pallet/) has a deprecation warning because `revoke_claim` and `create_claim` do not have the `pallet::call_index` attribute defined. This pull request removes that deprecation warning by adding the `call_index` attribute to each. 