### PR TITLE
docs: fix typo

### DIFF
--- a/content/md/en/docs/tutorials/connect-relay-and-parachains/connect-a-local-parachain.md
+++ b/content/md/en/docs/tutorials/connect-relay-and-parachains/connect-a-local-parachain.md
@@ -314,7 +314,7 @@ To register the parachain:
    
    After you submit the transaction, click **Network** and select **Explorer**.
 
-8. Check the list of recent events for successful `sudo.Suid` and click the event to see details about the transaction.
+8. Check the list of recent events for successful `sudo.Sudid` and click the event to see details about the transaction.
    
    ![View the Sudo registration event](/media/images/docs/tutorials/parachains/sudo-registration-event.png)
 


### PR DESCRIPTION
Corrects event name to match accompanying image.