### PR TITLE
Collectibles review: prepare and orientation

### DIFF
--- a/content/md/en/docs/tutorials/collectibles-workshop/02-orientation.md
+++ b/content/md/en/docs/tutorials/collectibles-workshop/02-orientation.md
@@ -126,9 +126,9 @@ This workshop isn’t about learning Rust, but there are a few basic concepts th
 Most languages use either garbage collection or manually encoded operations to allocate and free up memory. In Rust, ownership is what controls how programs manage memory. 
 At a high level, ownership consists of three simple rules that the compiler checks:
 
-Each value has an owner that’s identified by the variable that holds the value.
-A value can only have one owner at a time.
-If the owner goes out of scope, the value is dropped.
+- Each value has an owner that’s identified by the variable that holds the value.
+- A value can only have one owner at a time.
+- If the owner goes out of scope, the value is dropped.
 
 To prevent a value from being dropped when you want to reuse it, you can borrow it.
 In Rust, you can add an ampersand (&) in front of a variable identifier to indicate that you want to borrow its value. By adding the ampersand, you can reuse the value multiple times throughout a function.
@@ -141,13 +141,15 @@ In Substrate, traits provide a flexible abstraction for defining shared behavior
 
 ### Functions that return errors
 
-In Rust, functions must return the Result type to handle errors. The returned Result is either Ok() for success or Err() for a failure.
+In Rust, functions must return the `Result` type to handle errors. The returned Result is either `Ok()` for success or `Err()` for a failure.
 For example:
 
+```rust
 match my_function() {
     Ok(value) => value,
     Err(msg) => return Err(msg),
 }
+```
 
 ### Macros
 


### PR DESCRIPTION
This PR makes minor formatting edits for the [Get oriented](https://docs.substrate.io/tutorials/collectibles-workshop/02-orientation/) section of the [Collectibles workshop](https://docs.substrate.io/tutorials/collectibles-workshop/).

-------

A couple things I noted in this review - @lisa-parity if you can address these comments, I'm happy to update the PR accordingly:

- In [002](https://docs.substrate.io/tutorials/collectibles-workshop/02-orientation/) it says: “If you completed the checklist in [Prepare a working environment](https://docs.substrate.io/tutorials/collectibles-workshop/01-prepare/), you have successfully compiled a Substrate node.” This isn't true, AFAICS there's no part in "01-prepare" that steps through compiling the node (or points to a resource that steps through doing this).
    - Knowing where these steps live, I went to [quick start](https://docs.substrate.io/quick-start/) to compile the node template. Only then was I able to continue with the "Rename your workspace" section.
    - Suggestion: either point users to the [Quick Start](https://docs.substrate.io/quick-start/) section or write out the steps to clone and compile the node on this page (although I think avoiding duplicate content is better).

- This section: “Start the node in development mode” and "A brief introduction to Rust" is a little much information in the context of this workshop for a complete new comer imo.
    - As a user, do I need to start the node right now? Shouldn't I already know the basics (e.g. Rust for Substrate and how to launch a node) if I've embarked on the mission to do this workshop?
        - Suggestion: the tutorial should assume this was done in Quick Start that way it can start right from “Start customizing what this blockchain does.” Imo it suffices to point users to these existing resources in [Pallet builder basics](https://docs.substrate.io/tutorials/collectibles-workshop/runtime-and-pallets/).