### PR TITLE
Fixed typo in link

### DIFF
--- a/content/md/en/docs/quick-start/modify-the-runtime.md
+++ b/content/md/en/docs/quick-start/modify-the-runtime.md
@@ -4,7 +4,7 @@ description: Make simple changes to the default node template to create a custom
 keywords:
 ---
 
-In [Explore the code](/quick-start/explore the-code/), you learned about the manifest files and Rust modules that make up the default node template.
+In [Explore the code](/quick-start/explore-the-code/), you learned about the manifest files and Rust modules that make up the default node template.
 Now that you have a general idea of what the runtime source code looks like, let's look at how easy it is for you to make a few simple changes to customize the runtime.
 
 For this simple demonstration, you are going to do the following:


### PR DESCRIPTION
Fixed typo in the link of "Explore the code".