### PR TITLE
fix link in prepare-your-first-contract.md

### DIFF
--- a/content/md/en/docs/tutorials/smart-contracts/prepare-your-first-contract.md
+++ b/content/md/en/docs/tutorials/smart-contracts/prepare-your-first-contract.md
@@ -164,7 +164,7 @@ The `lib.rs` file also contains two functions for testing that the contract work
 
 As you progress through the tutorial, you'll modify different parts of the starter code.
 By the end of the tutorial, you'll have a more advanced smart contract that looks like the
-[Flipper example](https://github.com/paritytech/ink/blob/master/examples/flipper/lib.rs).
+[Flipper example](https://github.com/paritytech/ink-examples/blob/main/flipper/lib.rs).
 
 To explore the default project files:
 


### PR DESCRIPTION
Updated the link that points to the ink example `Flipper` since all ink examples were moved in a separate repository.