### PR TITLE
protobuf is required for all (Apple Silicon & intel clip as well)

### DIFF
--- a/content/md/en/docs/install/macos.md
+++ b/content/md/en/docs/install/macos.md
@@ -16,12 +16,6 @@ Before you install Rust and set up your development environment on macOS, verify
 - Storage of at 10 GB available space.
 - Broadband Internet connection.
 
-### Support for Apple Silicon
-
-Protobuf must be installed before the build process can begin. To install it, run the following command:
-
-`brew install protobuf`
-
 ### Install Homebrew
 
 In most cases, you should use Homebrew to install and manage packages on macOS computers.
@@ -69,6 +63,12 @@ To install `openssl` and the Rust toolchain on macOS:
 
    ```bash
    brew install openssl
+   ```
+   
+1. Install the `protoc` package by running the following command:
+
+   ```bash
+   brew install protobuf
    ```
 
 1. Download the `rustup` installation program and use it to install Rust by running the following command:


### PR DESCRIPTION
https://substrate.stackexchange.com/questions/4015/failed-to-run-custom-build-command-for-libp2p-core-v0-34-0

error: failed to run custom build command for `libp2p-core v0.38.0`

Caused by:
  process didn't exit successfully: `/Users/adibir/Desktop/Impactility/substrate-node-template/target/release/build/libp2p-core-af21bf2b03805b28/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.You could try running `brew install protobuf` or downloading it from https://github.com/protocolbuffers/protobuf/releases

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ', /Users/adibir/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.11.9/src/lib.rs:1457:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...