### PR TITLE
Fix typo on use-maps-for-storing-values.md

### DIFF
--- a/content/md/en/docs/tutorials/smart-contracts/use-maps-for-storing-values.md
+++ b/content/md/en/docs/tutorials/smart-contracts/use-maps-for-storing-values.md
@@ -135,7 +135,7 @@ To add a storage map to the `incrementer` contract:
 1. Import the `Mapping` type.
 
    ```rust
-   #[ink::contract
+   #[ink::contract]
    mod incrementer {
        use ink::storage::Mapping;
    ```


### PR DESCRIPTION
This is a small change that fixes the rust syntax on the mapping tutorial.