### PR TITLE
Fix wrong branch of new repository

### DIFF
--- a/content/md/en/docs/test/simulate-parachains.md
+++ b/content/md/en/docs/test/simulate-parachains.md
@@ -60,15 +60,9 @@ To prepare a working folder with the binaries for the test network:
 1. Checkout the latest release of Polkadot.
 
    Release branches use the naming convention `release-v<n.n.n>`.
-   For example, the release branch used in this tutorial is `release-v1.0.0`.
-   You can check out a more recent release branch instead of using `release-v1.0.0`.
+   For example, the release branch used in this tutorial is `release-v1.0.0` which is in master branch.
+   You can check out a more recent release branch instead of using `git checkout release-v1.1.0`.
    You can find information about recent releases and what's included in each release on the [Releases](https://github.com/paritytech/polkadot/releases) tab.
-
-   For example:
-
-   ```bash
-   git checkout release-v1.0.0
-   ```
 
 1. Compile the relay chain node by running the following command:
 


### PR DESCRIPTION
The new repo doesn't have the branch release-v1.0.0, I have seen people having issues with that in StackExchange: 

- https://substrate.stackexchange.com/questions/9839/cant-start-test-network-using-zombienet-macos
-  https://substrate.stackexchange.com/questions/9981/what-version-of-polkadot-relaychain-and-substrate-parachain-template-can-be-used

The options I see are: 
 1. Use `git clone https://github.com/paritytech/polkadot` to the old repo
 2.  Don’t do the `git checkout release-v1.0.0 `and keep the user in master branch
 3.  Update everything to work with the version `release-v1.1.0`
 
My fix uses the option 2, but feel free to suggest the fix to one you consider better.