### PR TITLE
replaced i32 by u32 to avoid compilation conflicts

### DIFF
--- a/content/md/en/docs/tutorials/smart-contracts/use-maps-for-storing-values.md
+++ b/content/md/en/docs/tutorials/smart-contracts/use-maps-for-storing-values.md
@@ -250,7 +250,7 @@ To add insert and remove functions to the contract:
 
    ```rust
    #[ink(message)]
-   pub fn inc_mine(&mut self, by: i32) {
+   pub fn inc_mine(&mut self, by: u32) {
        let caller = self.env().caller();
        let my_value = self.get_mine();
        self.my_map.insert(caller, &(my_value + by));


### PR DESCRIPTION
In prev definition of the function it was accepting an i32 to be added by a u32 var which was causing compile error.