### PR TITLE
Add deprecated banner to xcm reference and link to rust docs

### DIFF
--- a/content/md/en/docs/reference/xcm-reference.md
+++ b/content/md/en/docs/reference/xcm-reference.md
@@ -9,7 +9,12 @@ keywords:
 ---
 
 <div class="warning">
-  <strong>⚠️ WARNING:</strong> This page contains outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/xcm/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
+	</p>
+	<p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/xcm/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
+	</p>
 </div>
 
 This section provides reference information for the cross-consensus message (XCM) format.

--- a/content/md/en/docs/reference/xcm-reference.md
+++ b/content/md/en/docs/reference/xcm-reference.md
@@ -8,6 +8,10 @@ keywords:
   - errors
 ---
 
+<div class="warning">
+  <strong>⚠️ WARNING:</strong> This page contains outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/xcm/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
+</div>
+
 This section provides reference information for the cross-consensus message (XCM) format.
 
 ## Instructions


### PR DESCRIPTION
The xcm reference page holds outdated information that is now up-to-date in the rust docs.
This is part of the plan to move our documentation to rust docs.