### PR TITLE
Remove all links to Substrate Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Default localhost port configuration:
 ```env
 GATSBY_WEBSITE_URL=http://localhost:8100
 GATSBY_DOCS_URL=http://localhost:8200
-GATSBY_MARKETPLACE_URL=http://localhost:8300
 GATSBY_CAREERS_URL=https://careers.substrate.io
 ```
 

--- a/config/menus.js
+++ b/config/menus.js
@@ -1,4 +1,4 @@
-const { MARKETPLACE_URL, WEBSITE_URL, CAREERS_URL } = require('./webConsts.js');
+const { WEBSITE_URL, CAREERS_URL } = require('./webConsts.js');
 
 /* the main menu, ids of items must match
    the submenu's key of this js object */
@@ -57,10 +57,6 @@ const developers = [
   {
     url: 'https://paritytech.github.io/substrate/master/sc_service/',
     id: 'developers.rustdocs',
-  },
-  {
-    url: MARKETPLACE_URL,
-    id: 'developers.marketplace',
   },
   {
     url: WEBSITE_URL + '/developers/smart-contracts/',

--- a/config/siteMetadata.js
+++ b/config/siteMetadata.js
@@ -1,5 +1,5 @@
 const menus = require('./menus.js');
-const { WEBSITE_URL, DOCS_URL, MARKETPLACE_URL, CAREERS_URL } = require('./webConsts.js');
+const { WEBSITE_URL, DOCS_URL, CAREERS_URL } = require('./webConsts.js');
 
 module.exports = {
   menus,
@@ -10,7 +10,6 @@ module.exports = {
   siteUrl: DOCS_URL,
   websiteUrl: WEBSITE_URL,
   docsUrl: DOCS_URL,
-  marketplaceUrl: MARKETPLACE_URL,
   careersUrl: CAREERS_URL,
   author: 'Parity WebDev/W3F WebOps',
   pressEmail: 'press@parity.io',

--- a/config/webConsts.js
+++ b/config/webConsts.js
@@ -1,11 +1,9 @@
 const WEBSITE_URL = process.env.GATSBY_WEBSITE_URL;
 const DOCS_URL = process.env.GATSBY_DOCS_URL;
-const MARKETPLACE_URL = process.env.GATSBY_MARKETPLACE_URL;
 const CAREERS_URL = process.env.GATSBY_CAREERS_URL;
 
 module.exports = {
   WEBSITE_URL,
   DOCS_URL,
-  MARKETPLACE_URL,
   CAREERS_URL,
 };

--- a/content/locales/en/menus.json
+++ b/content/locales/en/menus.json
@@ -14,7 +14,6 @@
   "developers.home": "Home",
   "developers.docs": "Docs",
   "developers.rustdocs": "Rust Docs",
-  "developers.marketplace": "Marketplace",
   "developers.smart-contracts": "Smart Contracts",
   "developers.substrate-connect": "Substrate Connect",
   "developers.rococo-network": "Rococo Network",

--- a/example.env.development
+++ b/example.env.development
@@ -1,4 +1,3 @@
 # GATSBY_WEBSITE_URL=http://localhost:8100
 # GATSBY_DOCS_URL=http://localhost:8200
-# GATSBY_MARKETPLACE_URL=http://localhost:8300
 # GATSBY_CAREERS_URL=https://careers.substrate.io

--- a/example.env.production
+++ b/example.env.production
@@ -1,4 +1,3 @@
 # GATSBY_WEBSITE_URL=http://localhost:8100
 # GATSBY_DOCS_URL=http://localhost:8200
-# GATSBY_MARKETPLACE_URL=http://localhost:8300
 # GATSBY_CAREERS_URL=https://careers.substrate.io


### PR DESCRIPTION
The marketplace content is unmaintained so it should no longer be featured on the Substrate docs.