### PR TITLE
Rephrase networks-and-nodes.md documentation

### DIFF
--- a/content/md/en/docs/learn/networks-and-nodes.md
+++ b/content/md/en/docs/learn/networks-and-nodes.md
@@ -58,7 +58,7 @@ If you need to query historical blocks, you should purge the full node then rest
 ### Archive nodes
 
 Archive nodes are similar to full nodes except that they do not discard old states. As a result, they have complete state for every block available without computation.
-For this reason, archive nodes are often used by utilities&nbsp;—&nbsp;such as block explorers, wallets, discussion forums, and similar applications&nbsp;—&nbsp;that need access to historical information.
+For this reason, archive nodes are often used by utilities — such as block explorers, wallets, discussion forums, and similar applications — that need access to historical information.
 
 ![Archive nodes](/media/images/docs/archive-node.png)
 

--- a/content/md/en/docs/learn/networks-and-nodes.md
+++ b/content/md/en/docs/learn/networks-and-nodes.md
@@ -29,7 +29,7 @@ For example, Substrate blockchains are used to build the following network types
 
 Blockchains require network nodes to be synchronised to present a consistent and up-to-date view of the blockchain state.
 Each synchronised node stores a copy of the blockchain and keeps track of incoming transactions.
-However, keeping a full copy of an entire blockchain requires a lot of storage and computing resources and downloading all of the blocks from genesis to the most recent isn’t practical for most use cases.
+However, keeping a full copy of an entire blockchain requires a lot of storage and downloading all of the blocks from genesis to the most recent isn’t practical for most use cases.
 To make it easier to maintain the security and integrity of the chain but reduce the resource requirements for clients wanting access to blockchain data, there are different types of nodes that can interact with the chain:
 
 - [Full nodes](#full-nodes)
@@ -39,16 +39,16 @@ To make it easier to maintain the security and integrity of the chain but reduce
 ### Full nodes
 
 Full nodes are a critical part of the blockchain network infrastructure and are the most common node type.
-Full nodes store blockchain data and, typically, participate in common blockchain operations, such as authoring and validating blocks, receiving and verifying transactions, and serving data in response to user requests.
+Full nodes store blockchain data and, typically, participate in common blockchain operations, such as validating blocks, receiving and verifying transactions, and serving data in response to user requests.
 
 ![Full node](/media/images/docs/full-node.png)
 
-By default, full nodes are configured to store only the most recent 256 blocks and to discard state older than that—with the exception of the genesis block—to prevent the full node from growing indefinitely and consuming all available disk space.
-You can configure the number of blocks a full node retains.
+By default, full nodes are configured to store all the blocks but only the most recent 256 states. They discard states older than that&nbsp;—&nbsp;with the exception of the genesis block&nbsp;—&nbsp;to prevent the full node from consuming too much disk space.
+You can configure the number of blocks a full node retains (see `--{state,blocks}-pruning` options).
 
-Although older blocks are discarded, full nodes retain all of the [block headers](/reference/glossary/#header) from the genesis block to the most recent block to validate that the state is correct.
-Because the full node has access to all of the block headers, it can be used to rebuild the state of the entire blockchain by executing all of the blocks from the genesis block.
-Thus it requires much more computation to retrieve information about some previous state, and an archive should generally be used instead.
+Although older states are discarded, full nodes retain all the blocks from genesis to the head, allowing to rebuild all the intermediate states.
+It is achieved by taking the genesis state as initial state and executing all the blocks successively on top of if.
+Retrieving information about some previous state thus requires an expensive computation which can be avoided by using an archive node, which does not discard the states.
 
 Full nodes allow you to read the current state of the chain and to submit and validate transactions directly on the network.
 By discarding state from older blocks, a full node requires much less disk space than an archive node.
@@ -57,8 +57,8 @@ If you need to query historical blocks, you should purge the full node then rest
 
 ### Archive nodes
 
-Archive nodes are similar to full nodes except that they store all past blocks with complete state available for every block.
-Archive nodes are most often used by utilities—such as block explorers, wallets, discussion forums, and similar applications—that need access to historical information.
+Archive nodes are similar to full nodes except that they do not discard old states. As a result, they have complete state for every block available without computation.
+For this reason, archive nodes are often used by utilities&nbsp;—&nbsp;such as block explorers, wallets, discussion forums, and similar applications&nbsp;—&nbsp;that need access to historical information.
 
 ![Archive nodes](/media/images/docs/archive-node.png)
 

--- a/content/md/en/docs/learn/networks-and-nodes.md
+++ b/content/md/en/docs/learn/networks-and-nodes.md
@@ -47,7 +47,7 @@ By default, full nodes are configured to store all the blocks but only the most 
 You can configure the number of blocks a full node retains (see `--state-pruning` and `--blocks-pruning` options).
 
 Although older states are discarded, full nodes retain all the blocks from genesis to the head, allowing them to rebuild all the intermediate states.
-It is achieved by taking the genesis state as initial state and executing all the blocks successively on top of if.
+This is achieved by taking the genesis state as initial state and executing all the blocks successively on top of if.
 Retrieving information about some previous state thus requires an expensive computation which can be avoided by using an archive node, which does not discard the states.
 
 Full nodes allow you to read the current state of the chain and to submit and validate transactions directly on the network.

--- a/content/md/en/docs/learn/networks-and-nodes.md
+++ b/content/md/en/docs/learn/networks-and-nodes.md
@@ -44,7 +44,7 @@ Full nodes store blockchain data and, typically, participate in common blockchai
 ![Full node](/media/images/docs/full-node.png)
 
 By default, full nodes are configured to store all the blocks but only the most recent 256 states. They discard states older than that&nbsp;—&nbsp;with the exception of the genesis block&nbsp;—&nbsp;to prevent the full node from consuming too much disk space.
-You can configure the number of blocks a full node retains (see `--{state,blocks}-pruning` options).
+You can configure the number of blocks a full node retains (see `--state-pruning` and `--blocks-pruning` options).
 
 Although older states are discarded, full nodes retain all the blocks from genesis to the head, allowing to rebuild all the intermediate states.
 It is achieved by taking the genesis state as initial state and executing all the blocks successively on top of if.

--- a/content/md/en/docs/learn/networks-and-nodes.md
+++ b/content/md/en/docs/learn/networks-and-nodes.md
@@ -46,7 +46,7 @@ Full nodes store blockchain data and, typically, participate in common blockchai
 By default, full nodes are configured to store all the blocks but only the most recent 256 states. They discard states older than that&nbsp;—&nbsp;with the exception of the genesis block&nbsp;—&nbsp;to prevent the full node from consuming too much disk space.
 You can configure the number of blocks a full node retains (see `--state-pruning` and `--blocks-pruning` options).
 
-Although older states are discarded, full nodes retain all the blocks from genesis to the head, allowing to rebuild all the intermediate states.
+Although older states are discarded, full nodes retain all the blocks from genesis to the head, allowing them to rebuild all the intermediate states.
 It is achieved by taking the genesis state as initial state and executing all the blocks successively on top of if.
 Retrieving information about some previous state thus requires an expensive computation which can be avoided by using an archive node, which does not discard the states.
 

--- a/content/md/en/docs/learn/networks-and-nodes.md
+++ b/content/md/en/docs/learn/networks-and-nodes.md
@@ -43,7 +43,7 @@ Full nodes store blockchain data and, typically, participate in common blockchai
 
 ![Full node](/media/images/docs/full-node.png)
 
-By default, full nodes are configured to store all the blocks but only the most recent 256 states. They discard states older than that&nbsp;—&nbsp;with the exception of the genesis block&nbsp;—&nbsp;to prevent the full node from consuming too much disk space.
+By default, full nodes are configured to store all the blocks but only the most recent 256 states. They discard states older than that — with the exception of the genesis block — to prevent the full node from consuming too much disk space.
 You can configure the number of blocks a full node retains (see `--state-pruning` and `--blocks-pruning` options).
 
 Although older states are discarded, full nodes retain all the blocks from genesis to the head, allowing them to rebuild all the intermediate states.


### PR DESCRIPTION
I found this documentation confusing because it mixed `--state-pruning` and `--blocks-pruning` concepts and made think that full nodes discard the blocks when they actually discard the states. I come with this rewrite as a suggestion but it may require proofreading by an expert.

As a reminder this is the current node documentation:

 ```
      --state-pruning <PRUNING_MODE>
          Specify the state pruning mode.
          
          This mode specifies when the block's state (ie, storage) should be pruned (ie, removed) from the database.
          This setting can only be set on the first creation of the database. Every subsequent run will load the pruning
          mode from the database and will error if the stored mode doesn't match this CLI value. It is fine to drop this
          CLI flag for subsequent runs. Possible values: - archive: Keep the state of all blocks. - 'archive-canonical'
          Keep only the state of finalized blocks. - number Keep the state of the last number of finalized blocks.
          [default: 256]

      --blocks-pruning <PRUNING_MODE>
          Specify the blocks pruning mode.
          
          This mode specifies when the block's body (including justifications) should be pruned (ie, removed) from the
          database. Possible values: - 'archive' Keep all blocks. - 'archive-canonical' Keep only finalized blocks. -
          number Keep the last `number` of finalized blocks.
          
          [default: archive-canonical]
```