### PR TITLE
Update Postman docs link in explore-sidecar-endpoints.md

### DIFF
--- a/content/md/en/docs/tutorials/integrate-with-tools/explore-sidecar-endpoints.md
+++ b/content/md/en/docs/tutorials/integrate-with-tools/explore-sidecar-endpoints.md
@@ -94,7 +94,7 @@ To download and install `sidecar`:
 
 To use the predefined API collection for `sidecar`:
 
-1. Open the predefined [Substrate API Sidecar](https://documenter.getpostman.com/view/24602305/2s8YsqWaj8#intro) API collection in a browser.
+1. Open the predefined [Substrate API Sidecar](https://documenter.getpostman.com/view/21393319/2sA3Qs9C9M#intro) API collection in a browser.
 2. Click **Run in Postman** in the top-right corner of the page.
 3. Select to run the collection either using Postman for Web or in the Postman for Mac desktop client.
 


### PR DESCRIPTION
#### Description
Update Postman Collection link so that it includes the full docs (path params, query params, etc) in all the endpoints.

- [Previous Postman Documentation](https://documenter.getpostman.com/view/24602305/2s8YsqWaj8#intro) has no info on each endpoint. Example : [Account Asset Approvals](https://documenter.getpostman.com/view/24602305/2s8YsqWaj8#431e27f8-b902-4fc5-b9bc-fa8aadf9c0bf)
- [New Postman Link](https://documenter.getpostman.com/view/21393319/2sA3Qs9C9M#intro) includes all the necessary info and are aligned and up to date with the [OpenAPI](https://paritytech.github.io/substrate-api-sidecar/dist/) docs of Sidecar. Example : [Account Asset Approvals](https://documenter.getpostman.com/view/21393319/2sA3Qs9C9M#6205139b-8865-432f-ac2b-d4733101fd35)

#### Related Sidecar Issue
https://github.com/paritytech/substrate-api-sidecar/issues/1440

 
