### PR TITLE
Remove wrong stuff from minimal-pallet tut

### DIFF
--- a/content/md/en/docs/learn/runtime-development.md
+++ b/content/md/en/docs/learn/runtime-development.md
@@ -139,7 +139,6 @@ pub mod pallet {
  // Declare the pallet type
  // This is a placeholder to implement traits and methods.
  #[pallet::pallet]
- #[pallet::generate_store(pub(super) trait Store)]
  pub struct Pallet<T>(_);
 
  // Add the runtime configuration trait

--- a/content/md/en/docs/reference/frame-macros.md
+++ b/content/md/en/docs/reference/frame-macros.md
@@ -256,15 +256,6 @@ For example:
 pub struct Pallet<T>(_);
 ```
 
-This macro can generate the `Store` trait to contain an associated type for each storage item if you provide the `#[pallet::generate_store($vis trait Store)]` attribute macro.
-
-For example:
-
-```rust
-#[pallet::pallet]
-pub struct Pallet<T>(_);
-```
-
 For more information about working with storage and this macro, see the [macro expansion](https://paritytech.github.io/substrate/master/frame_support/attr.pallet.html#macro-expansion-1) added to the `struct Pallet<T>` definition.
 
 ### #[pallet::without\_storage\_info]
@@ -279,7 +270,6 @@ To use it, add the `#[pallet::without_storage_info]` attribute to the pallet str
 
 ```rust
 #[pallet::pallet]
-#[pallet::generate_store(pub(super) trait Store)]
 #[pallet::without_storage_info]
 pub struct Pallet<T>(_);
 ```

--- a/content/md/en/docs/tutorials/collectibles-workshop/03-create-pallet.md
+++ b/content/md/en/docs/tutorials/collectibles-workshop/03-create-pallet.md
@@ -3,6 +3,8 @@ title: Create a new pallet
 tutorial: 1
 ---
 
+> ⚠️ This tutorial is out-of-date any may not work as intended. Please refer to [`Polkadot SDK Docs`](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html) for up-to-date information.
+
 In this workshop, you'll learn how to create a custom Substrate module-called a pallet-that's going to contain the code for your application-specific blockchain.
 Pallets are built using FRAME libraries and the Rust programming language.
 FRAME includes a lot of specialized macros that make it easy to compose the application logic in a reusable container.
@@ -104,14 +106,14 @@ To update the manifest for the collectibles project:
    
    ```toml
    [dependencies]
-   frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "polkadot-v1.0.0"}
-   frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "polkadot-v1.0.0" }
+   frame-support = { default-features = false, version = "36.0.0" }
+   frame-system = { default-features = false, version = "36.0.0" }
    ```
 
 3. Add `codec` and `scale-info` to the dependencies.
    
    ```toml
-   codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive",] }
+   codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
    scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
    ```
 
@@ -152,7 +154,6 @@ The next step is to prepare a set of common macros to serve as scaffolding for y
         use frame_system::pallet_prelude::*;
 
         #[pallet::pallet]
-        #[pallet::generate_store(pub(super) trait Store)]
         pub struct Pallet<T>(_);
 
         #[pallet::config]


### PR DESCRIPTION
Removes some old and wrong stuff from the pallet tutorial, see: https://github.com/paritytech/polkadot-sdk/issues/5171  

Given that this is to be deprecated soon anyway, i only did the minimal changes and added a warning.